### PR TITLE
Feature/streamingcommunity provider domain updater

### DIFF
--- a/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsMobileFragment.kt
+++ b/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsMobileFragment.kt
@@ -3,8 +3,11 @@ package com.tanasi.streamflix.fragments.settings
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.text.InputType
 import android.view.inputmethod.EditorInfo
+import android.widget.Toast
 import androidx.navigation.fragment.findNavController
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
@@ -55,10 +58,16 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
 
             setOnPreferenceChangeListener { _, newValue ->
                 UserPreferences.streamingcommunityDomain = newValue as String
-                requireActivity().apply {
-                    finish()
-                    startActivity(Intent(this, this::class.java))
-                }
+
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.settings_streamingcommunity_close_app),
+                    Toast.LENGTH_LONG
+                ).show()
+                Handler(Looper.getMainLooper()).postDelayed({
+                    exitProcess(0)
+                }, 3000)
+
                 true
             }
         }

--- a/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsMobileFragment.kt
+++ b/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsMobileFragment.kt
@@ -14,7 +14,6 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.tanasi.streamflix.R
 import com.tanasi.streamflix.utils.UserPreferences
-import com.tanasi.streamflix.utils.toActivity
 import kotlin.system.exitProcess
 
 class SettingsMobileFragment : PreferenceFragmentCompat() {
@@ -54,11 +53,11 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
                 editText.inputType = InputType.TYPE_CLASS_TEXT
                 editText.imeOptions = EditorInfo.IME_ACTION_DONE
 
-                editText.hint = "streamingcommunity.spa"
+                editText.hint = "streamingcommunity.example"
 
                 val pref = UserPreferences.streamingcommunityDomain
                 if (pref.isNullOrEmpty())
-                    editText.setText("streamingcommunity.spa")
+                    editText.setText("streamingcommunity.example")
                 else
                     editText.setText(pref)
             }

--- a/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsMobileFragment.kt
+++ b/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsMobileFragment.kt
@@ -3,6 +3,8 @@ package com.tanasi.streamflix.fragments.settings
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.InputType
+import android.view.inputmethod.EditorInfo
 import androidx.navigation.fragment.findNavController
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
@@ -46,6 +48,8 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
             setDefaultValue(UserPreferences.streamingcommunityDomain)
 
             setOnBindEditTextListener { editText ->
+                editText.inputType = InputType.TYPE_CLASS_TEXT
+                editText.imeOptions = EditorInfo.IME_ACTION_DONE
                 editText.hint = "streamingcommunity.spa"
             }
 

--- a/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsMobileFragment.kt
+++ b/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsMobileFragment.kt
@@ -48,16 +48,24 @@ class SettingsMobileFragment : PreferenceFragmentCompat() {
         }
 
         findPreference<EditTextPreference>("p_settings_streamingcommunity_domain")?.apply {
-            setDefaultValue(UserPreferences.streamingcommunityDomain)
+            summary = UserPreferences.streamingcommunityDomain
 
             setOnBindEditTextListener { editText ->
                 editText.inputType = InputType.TYPE_CLASS_TEXT
                 editText.imeOptions = EditorInfo.IME_ACTION_DONE
+
                 editText.hint = "streamingcommunity.spa"
+
+                val pref = UserPreferences.streamingcommunityDomain
+                if (pref.isNullOrEmpty())
+                    editText.setText("streamingcommunity.spa")
+                else
+                    editText.setText(pref)
             }
 
             setOnPreferenceChangeListener { _, newValue ->
                 UserPreferences.streamingcommunityDomain = newValue as String
+                summary = newValue
 
                 Toast.makeText(
                     requireContext(),

--- a/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsTvFragment.kt
+++ b/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsTvFragment.kt
@@ -53,11 +53,11 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
                 editText.inputType = InputType.TYPE_CLASS_TEXT
                 editText.imeOptions = EditorInfo.IME_ACTION_DONE
 
-                editText.hint = "streamingcommunity.spa"
+                editText.hint = "streamingcommunity.example"
 
                 val pref = UserPreferences.streamingcommunityDomain
                 if (pref.isNullOrEmpty())
-                    editText.setText("streamingcommunity.spa")
+                    editText.setText("streamingcommunity.example")
                 else
                     editText.setText(pref)
             }

--- a/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsTvFragment.kt
+++ b/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsTvFragment.kt
@@ -47,16 +47,24 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
         }
 
         findPreference<EditTextPreference>("p_settings_streamingcommunity_domain")?.apply {
-            setDefaultValue(UserPreferences.streamingcommunityDomain)
+            summary = UserPreferences.streamingcommunityDomain
 
             setOnBindEditTextListener { editText ->
                 editText.inputType = InputType.TYPE_CLASS_TEXT
                 editText.imeOptions = EditorInfo.IME_ACTION_DONE
+
                 editText.hint = "streamingcommunity.spa"
+
+                val pref = UserPreferences.streamingcommunityDomain
+                if (pref.isNullOrEmpty())
+                    editText.setText("streamingcommunity.spa")
+                else
+                    editText.setText(pref)
             }
 
             setOnPreferenceChangeListener { _, newValue ->
                 UserPreferences.streamingcommunityDomain = newValue as String
+                summary = newValue
 
                 Toast.makeText(
                     requireContext(),

--- a/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsTvFragment.kt
+++ b/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsTvFragment.kt
@@ -3,8 +3,11 @@ package com.tanasi.streamflix.fragments.settings
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.text.InputType
 import android.view.inputmethod.EditorInfo
+import android.widget.Toast
 import androidx.leanback.preference.LeanbackPreferenceFragmentCompat
 import androidx.navigation.fragment.findNavController
 import androidx.preference.EditTextPreference
@@ -54,10 +57,16 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
 
             setOnPreferenceChangeListener { _, newValue ->
                 UserPreferences.streamingcommunityDomain = newValue as String
-                requireActivity().apply {
-                    finish()
-                    startActivity(Intent(this, this::class.java))
-                }
+
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.settings_streamingcommunity_close_app),
+                    Toast.LENGTH_LONG
+                ).show()
+                Handler(Looper.getMainLooper()).postDelayed({
+                    exitProcess(0)
+                }, 3000)
+
                 true
             }
         }

--- a/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsTvFragment.kt
+++ b/app/src/main/java/com/tanasi/streamflix/fragments/settings/SettingsTvFragment.kt
@@ -3,6 +3,8 @@ package com.tanasi.streamflix.fragments.settings
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.text.InputType
+import android.view.inputmethod.EditorInfo
 import androidx.leanback.preference.LeanbackPreferenceFragmentCompat
 import androidx.navigation.fragment.findNavController
 import androidx.preference.EditTextPreference
@@ -45,6 +47,8 @@ class SettingsTvFragment : LeanbackPreferenceFragmentCompat() {
             setDefaultValue(UserPreferences.streamingcommunityDomain)
 
             setOnBindEditTextListener { editText ->
+                editText.inputType = InputType.TYPE_CLASS_TEXT
+                editText.imeOptions = EditorInfo.IME_ACTION_DONE
                 editText.hint = "streamingcommunity.spa"
             }
 

--- a/app/src/main/java/com/tanasi/streamflix/providers/StreamingCommunityProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/StreamingCommunityProvider.kt
@@ -1,6 +1,5 @@
 package com.tanasi.streamflix.providers
 
-import android.util.Log
 import com.google.gson.annotations.SerializedName
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.tanasi.streamflix.adapters.AppAdapter
@@ -37,7 +36,6 @@ object StreamingCommunityProvider : Provider {
             if (!_domain.isNullOrEmpty())
                 return _domain!!
 
-            Log.e("DOMAIN", "cache miss reading userprefs")
             val storedDomain = UserPreferences.streamingcommunityDomain
 
             _domain = if (storedDomain.isNullOrEmpty())
@@ -49,7 +47,6 @@ object StreamingCommunityProvider : Provider {
         }
         set(value) {
             if (value != domain) {
-                Log.e("DOMAIN", "updating userprefs with $value")
                 _domain = value
                 UserPreferences.streamingcommunityDomain = value
                 service = StreamingCommunityService.build("https://$value/")
@@ -460,7 +457,7 @@ object StreamingCommunityProvider : Provider {
     }
 
 
-    class UserAgentInterceptor(private val userAgent: String) : Interceptor {
+    private class UserAgentInterceptor(private val userAgent: String) : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
             val originalRequest = chain.request()
             val requestWithUserAgent = originalRequest.newBuilder()
@@ -470,7 +467,7 @@ object StreamingCommunityProvider : Provider {
         }
     }
 
-    class RedirectInterceptor(): Interceptor {
+    private class RedirectInterceptor : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
             val response = chain.proceed(chain.request())
             val location = response.header("Location")
@@ -479,7 +476,6 @@ object StreamingCommunityProvider : Provider {
                     .substringBeforeLast("/")
                     .substringAfterLast("/")
             }
-            Log.e("Interceptor", "Request url: ${response.request.url}")
             return response
         }
     }
@@ -490,7 +486,6 @@ object StreamingCommunityProvider : Provider {
             private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
 
             fun build(baseUrl: String): StreamingCommunityService {
-                Log.e("SCService", "building retrofit")
                 val client = OkHttpClient.Builder()
                     .readTimeout(30, TimeUnit.SECONDS)
                     .connectTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/java/com/tanasi/streamflix/providers/StreamingCommunityProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/StreamingCommunityProvider.kt
@@ -29,6 +29,8 @@ import retrofit2.http.Query
 import java.util.concurrent.TimeUnit
 
 object StreamingCommunityProvider : Provider {
+    private const val DEFAULT_DOMAIN: String = "streamingcommunity.exposed"
+
     private var _domain: String? = null
     private var domain: String
         get() {
@@ -39,7 +41,7 @@ object StreamingCommunityProvider : Provider {
             val storedDomain = UserPreferences.streamingcommunityDomain
 
             _domain = if (storedDomain.isNullOrEmpty())
-                "streamingcommunity.spa"
+                DEFAULT_DOMAIN
             else
                 storedDomain
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -191,4 +191,5 @@
     <string name="settings_category_streamingcommunity">Impostazioni StreamingCommunity</string>
     <string name="settings_category_streamingcommunity_domain">Nome di dominio StreamingCommunity</string>
     <string name="settings_close_app">Chiudi applicazione</string>
+    <string name="settings_streamingcommunity_close_app">L\'app si chiuderà tra 3.. 2.. 1..</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,4 +191,5 @@
     <string name="settings_category_streamingcommunity">StreamingCommunity settings</string>
     <string name="settings_category_streamingcommunity_domain">StreamingCommunity domain name</string>
     <string name="settings_close_app">Close app</string>
+    <string name="settings_streamingcommunity_close_app">App will close in 3.. 2.. 1..</string>
 </resources>

--- a/app/src/main/res/xml/settings_mobile.xml
+++ b/app/src/main/res/xml/settings_mobile.xml
@@ -6,8 +6,7 @@
         <EditTextPreference
             android:key="p_settings_streamingcommunity_domain"
             android:title="@string/settings_category_streamingcommunity_domain"
-            android:inputType="text"
-            app:useSimpleSummaryProvider="true"/>
+            android:inputType="text"/>
     </PreferenceCategory>
 
     <Preference

--- a/app/src/main/res/xml/settings_tv.xml
+++ b/app/src/main/res/xml/settings_tv.xml
@@ -6,8 +6,7 @@
         <EditTextPreference
             android:key="p_settings_streamingcommunity_domain"
             android:title="@string/settings_category_streamingcommunity_domain"
-            android:inputType="text"
-            app:useSimpleSummaryProvider="true"/>
+            android:inputType="text"/>
     </PreferenceCategory>
 
     <Preference


### PR DESCRIPTION
- Automatically update the domain when there's a HTTP redirect
- Using getters for service and domain made the service to get re-built for every request and UserPreferences to get flooded with requests
- Sadly, restarting the activity doesn't work (the domain gets frequently blocked on italian DNS, which is why I think it's friendlier for the end user to close the app) (maybe some day I can come up with a better solution)

Thank you for your kind help! 😁