### PR TITLE
Preload series and match Extractor by name

### DIFF
--- a/app/src/main/java/com/tanasi/streamflix/extractors/Extractor.kt
+++ b/app/src/main/java/com/tanasi/streamflix/extractors/Extractor.kt
@@ -68,10 +68,7 @@ abstract class Extractor {
             val compareUrl = link.lowercase().replace(urlRegex, "")
 
             for (extractor in extractors) {
-                if ((server?.name?.lowercase() ?: "").contains(extractor.name.lowercase())){
-                    return extractor.extract(link)
-                }
-                else if (compareUrl.startsWith(extractor.mainUrl.replace(urlRegex, ""))) {
+                if (compareUrl.startsWith(extractor.mainUrl.replace(urlRegex, ""))) {
                     return extractor.extract(link)
                 } else {
                     for (aliasUrl in extractor.aliasUrls) {
@@ -102,6 +99,12 @@ abstract class Extractor {
                             return extractor.extract(link)
                         }
                     }
+                }
+            }
+
+            for (extractor in extractors){
+                if ((server?.name?.lowercase() ?: "").contains(extractor.name.lowercase())){
+                    return extractor.extract(link)
                 }
             }
             throw Exception("No extractors found")

--- a/app/src/main/java/com/tanasi/streamflix/providers/AniWorldProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/AniWorldProvider.kt
@@ -97,6 +97,7 @@ object AniWorldProvider : Provider {
     }
 
     override suspend fun getHome(): List<Category> {
+        preloadSeriesAlphabet()
         val document = service.getHome()
 
         val categories = mutableListOf<Category>()
@@ -421,7 +422,6 @@ object AniWorldProvider : Provider {
         val elements = document.select(".genre > ul > li")
 
         val loadedShows = elements.map {
-            val title = Jsoup.parse(it.text()).text()
             TvShow(
                 id = it.selectFirst("a[data-alternative-title]")
                     ?.attr("href")?.substringAfter("/anime/stream/")

--- a/app/src/main/java/com/tanasi/streamflix/providers/CuevanaDosProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/CuevanaDosProvider.kt
@@ -536,7 +536,7 @@ object CuevanaDosProvider : Provider {
             else -> videoUrl.toString()
         }
 
-        return Extractor.extract(link)
+        return Extractor.extract(link, server)
     }
 
 

--- a/app/src/main/java/com/tanasi/streamflix/providers/SerienStreamProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/SerienStreamProvider.kt
@@ -136,6 +136,7 @@ object SerienStreamProvider : Provider {
     }
 
     override suspend fun getHome(): List<Category> {
+        preloadSeriesAlphabet()
         val document = service.getHome()
         val categories = mutableListOf<Category>()
         categories.add(
@@ -194,7 +195,6 @@ object SerienStreamProvider : Provider {
         throw Exception("Keine Filme verfügbar")
     }
 
-    private var preloadJob: Job? = null
 
     private val cacheLock = Any()
 
@@ -397,17 +397,6 @@ object SerienStreamProvider : Provider {
             seriesCache.clear()
             isSeriesCacheLoaded = false
         }
-    }
-
-    fun getSeriesChunk(pageIndex: Int): List<TvShow> {
-        val fromIndex = pageIndex * chunkSize
-        if (fromIndex >= seriesCache.size) return emptyList()
-        val toIndex = minOf(fromIndex + chunkSize, seriesCache.size)
-        return seriesCache.subList(fromIndex, toIndex)
-    }
-
-    fun getTotalPages(): Int {
-        return (seriesCache.size + chunkSize - 1) / chunkSize
     }
 
 


### PR DESCRIPTION
preload series on get home for SerienStreamProvider.kt and AniWorldProvider.kt

pass server for CuevanaDosProvider.kt when trying to extract videos since some servers create new urls constantly, this way we can match the name of the server with the extractor making it so extractor is found. Use it as last resort