### PR TITLE
adding extractor Okru

### DIFF
--- a/app/src/main/java/com/tanasi/streamflix/extractors/Extractor.kt
+++ b/app/src/main/java/com/tanasi/streamflix/extractors/Extractor.kt
@@ -64,6 +64,7 @@ abstract class Extractor {
             RidooExtractor(),
             USTRExtractor(),
             VidGuardExtractor(),
+            OkruExtractor(),
         )
 
         suspend fun extract(link: String, server: Video.Server? = null): Video {

--- a/app/src/main/java/com/tanasi/streamflix/extractors/Extractor.kt
+++ b/app/src/main/java/com/tanasi/streamflix/extractors/Extractor.kt
@@ -63,6 +63,7 @@ abstract class Extractor {
             VeevExtractor(),
             RidooExtractor(),
             USTRExtractor(),
+            VidGuardExtractor(),
         )
 
         suspend fun extract(link: String, server: Video.Server? = null): Video {

--- a/app/src/main/java/com/tanasi/streamflix/extractors/OkruExtractor.kt
+++ b/app/src/main/java/com/tanasi/streamflix/extractors/OkruExtractor.kt
@@ -1,0 +1,89 @@
+package com.tanasi.streamflix.extractors
+
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.models.Video
+import okhttp3.OkHttpClient
+import org.jsoup.nodes.Document
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+class OkruExtractor : Extractor() {
+
+    override val name = "Okru"
+    override val mainUrl = "https://ok.ru"
+
+    private val service = Service.build(mainUrl)
+
+    override suspend fun extract(link: String): Video {
+        val document = service.get(link)
+
+        val videoString = document.selectFirst("div[data-options]")
+            ?.attr("data-options")
+            ?: throw Exception("No se encontró 'data-options' en la página de Ok.ru")
+
+        val arrayData = videoString.substringAfterLast("\\\"videos\\\":[{\\\"name\\\":\\\"").substringBefore("]")
+        val videos = arrayData.split("{\\\"name\\\":\\\"").reversed().mapNotNull {
+            val videoUrl = it.substringAfter("url\\\":\\\"").substringBefore("\\\"").replace("\\\\u0026", "&")
+            val quality = fixQuality(it.substringBefore("\\\""))
+
+            if (videoUrl.startsWith("https://")) {
+                Pair(quality, videoUrl)
+            } else {
+                null
+            }
+        }
+
+        if (videos.isEmpty()) {
+            throw Exception("No se encontraron videos válidos en el JSON de Ok.ru")
+        }
+
+        val bestVideoUrl = videos.first().second
+
+        return Video(
+            source = bestVideoUrl,
+            headers = mapOf("Referer" to mainUrl)
+        )
+    }
+
+    private fun fixQuality(quality: String): String {
+        return when (quality) {
+            "ultra" -> "2160p"
+            "quad" -> "1440p"
+            "full" -> "1080p"
+            "hd" -> "720p"
+            "sd" -> "480p"
+            "low" -> "360p"
+            "lowest" -> "240p"
+            "mobile" -> "144p"
+            else -> quality
+        }
+    }
+
+    private interface Service {
+        companion object {
+            fun build(baseUrl: String): Service {
+                val client = OkHttpClient.Builder()
+                    .followRedirects(true)
+                    .addInterceptor { chain ->
+                        val request = chain.request().newBuilder()
+                            .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36")
+                            .build()
+                        chain.proceed(request)
+                    }
+                    .build()
+
+                val retrofit = Retrofit.Builder()
+                    .baseUrl(baseUrl)
+                    .addConverterFactory(JsoupConverterFactory.create())
+                    .client(client)
+                    .build()
+
+                return retrofit.create(Service::class.java)
+            }
+        }
+
+        @GET
+        suspend fun get(@Url url: String): Document
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/extractors/VidGuardExtractor.kt
+++ b/app/src/main/java/com/tanasi/streamflix/extractors/VidGuardExtractor.kt
@@ -1,0 +1,83 @@
+package com.tanasi.streamflix.extractors
+
+import android.util.Base64
+import android.util.Log
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.models.Video
+import com.tanasi.streamflix.utils.PlaylistUtils
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+class VidGuardExtractor : Extractor() {
+    override val name = "VidG"
+    override val mainUrl = "https://vidguard.to"
+    override val aliasUrls = listOf(
+        "vembed.net", "bembed.cc", "vgfplay.com", "listeamed.net", "vidguard.to"
+    )
+
+    private val client = OkHttpClient()
+    private val service = Retrofit.Builder()
+        .baseUrl(mainUrl)
+        .addConverterFactory(ScalarsConverterFactory.create())
+        .client(client)
+        .build()
+        .create(VidGuardService::class.java)
+
+    private interface VidGuardService {
+        @GET
+        suspend fun get(@Url url: String): String
+    }
+
+    override suspend fun extract(link: String): Video {
+        Log.d("VidGuardExtractor", "--- INICIANDO ESPIONAJE DE SCRIPT (Extractor ENCONTRADO) ---")
+        Log.d("VidGuardExtractor", "URL recibida por el extractor: $link")
+
+        val pageHtml = try {
+            service.get(link)
+        } catch (e: Exception) {
+            service.get("https:$link")
+        }
+
+        val scriptData = pageHtml.substringAfter("eval(function(p,a,c,k,e,d)").substringBefore("</script>")
+            .let { "eval(function(p,a,c,k,e,d)$it" }
+
+        if (!scriptData.startsWith("eval")) {
+            throw Exception("No se encontró el script eval. El HTML puede haber cambiado.")
+        }
+
+        Log.d("VidGuardExtractor", "Script 'eval' capturado: $scriptData")
+        Log.d("VidGuardExtractor", "--- FIN DEL ESPIONAJE ---")
+
+        throw Exception("Misión de espionaje completada. Por favor, envía el log al asistente.")
+    }
+
+    private fun sigDecode(url: String): String {
+        val sig = url.split("sig=")[1].split("&")[0]
+        val decodedSig = sig.chunked(2)
+            .joinToString("") { (Integer.parseInt(it, 16) xor 2).toChar().toString() }
+            .let {
+                val padding = when (it.length % 4) {
+                    2 -> "=="
+                    3 -> "="
+                    else -> ""
+                }
+                String(Base64.decode((it + padding).toByteArray(), Base64.DEFAULT))
+            }
+            .dropLast(5)
+            .reversed()
+            .toCharArray()
+            .apply {
+                for (i in indices step 2) {
+                    if (i + 1 < size) {
+                        this[i] = this[i + 1].also { this[i + 1] = this[i] }
+                    }
+                }
+            }
+            .concatToString()
+            .dropLast(5)
+        return url.replace(sig, decodedSig)
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/extractors/VidHideExtractor.kt
+++ b/app/src/main/java/com/tanasi/streamflix/extractors/VidHideExtractor.kt
@@ -2,7 +2,6 @@ package com.tanasi.streamflix.extractors
 
 import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
 import com.tanasi.streamflix.models.Video
-import com.tanasi.streamflix.providers.RidomoviesProvider.URL
 import com.tanasi.streamflix.utils.JsUnpacker
 import com.tanasi.streamflix.utils.UserPreferences
 import org.jsoup.nodes.Document
@@ -15,38 +14,53 @@ import java.net.URL
 class VidHideExtractor: Extractor() {
     override val name = "VidHide"
     override val mainUrl = "https://dhtpre.com"
-    override val aliasUrls= listOf("https://peytonepre.com")
+
+    override val aliasUrls = listOf(
+        "https://peytonepre.com",
+        "https://vidhideplus.com/"
+    )
+
     companion object {
-        const val DEFAULT_USER_AGENT =
+        private const val DEFAULT_USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0"
     }
+
     override suspend fun extract(link: String): Video {
         val mainLink = URL(link).protocol + "://" + URL(link).host
         val service = Service.build(mainLink)
-
-        val source = service.getSource(link,  UserPreferences.currentProvider!!.baseUrl, UserPreferences.currentProvider!!.baseUrl, DEFAULT_USER_AGENT)
+        val source = service.getSource(
+            url = link,
+            referer = UserPreferences.currentProvider!!.baseUrl,
+            origin = UserPreferences.currentProvider!!.baseUrl,
+            userAgent = DEFAULT_USER_AGENT
+        )
         val packedJS = Regex("(eval\\(function\\(p,a,c,k,e,d\\)(.|\\n)*?)</script>")
             .find(source.toString())?.let { it.groupValues[1] }
             ?: throw Exception("Packed JS not found")
+
         val unPacked = JsUnpacker(packedJS).unpack()
             ?: throw Exception("Unpacked is null")
+
         val links = mutableMapOf<String, String>()
         Regex("""["'](hls\d+)["']\s*:\s*["'](.*?)["']""")
             .findAll(unPacked)
             .forEach {
                 links[it.groupValues[1]] = it.groupValues[2]
             }
+
         val finalUrl = links["hls4"] ?: links["hls2"] ?: throw Exception("No HLS link found")
 
-        return Video(
-            source = finalUrl
-        )
+        return Video(source = finalUrl)
     }
 
-
-
-
     private interface Service {
+        @GET
+        suspend fun getSource(
+            @Url url: String,
+            @Header("Referer") referer: String,
+            @Header("Origin") origin: String,
+            @Header("User-Agent") userAgent: String = DEFAULT_USER_AGENT
+        ): Document
 
         companion object {
             fun build(baseUrl: String): Service {
@@ -54,17 +68,8 @@ class VidHideExtractor: Extractor() {
                     .baseUrl(baseUrl)
                     .addConverterFactory(JsoupConverterFactory.create())
                     .build()
-
                 return retrofit.create(Service::class.java)
             }
         }
-
-        @GET
-
-        suspend fun getSource(@Url url: String,
-                              @Header("Referer") referer: String,
-                              @Header("Origin") origin: String,
-                              @Header("User-Agent") userAgent: String = DEFAULT_USER_AGENT
-        ): Document
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/models/animeflv/AnimeFlvModels.kt
+++ b/app/src/main/java/com/tanasi/streamflix/models/animeflv/AnimeFlvModels.kt
@@ -1,0 +1,16 @@
+package com.tanasi.streamflix.models.animeflv
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ServerModel(
+    @SerialName("SUB")
+    val sub: List<Sub> = emptyList(),
+)
+
+@Serializable
+data class Sub(
+    val title: String? = "",
+    val code: String = "",
+)

--- a/app/src/main/java/com/tanasi/streamflix/models/cinecalidad/CineCalidadModels.kt
+++ b/app/src/main/java/com/tanasi/streamflix/models/cinecalidad/CineCalidadModels.kt
@@ -1,0 +1,1 @@
+package com.tanasi.streamflix.models.cinecalidad

--- a/app/src/main/java/com/tanasi/streamflix/models/flixlatam/FlixLatamModels.kt
+++ b/app/src/main/java/com/tanasi/streamflix/models/flixlatam/FlixLatamModels.kt
@@ -1,0 +1,23 @@
+package com.tanasi.streamflix.models.flixlatam
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlayerResponse(
+    val embed_url: String = "",
+    val type: String = "",
+)
+
+@Serializable
+data class DataLinkItem(
+    val file_id: Int,
+    val video_language: String,
+    val sortedEmbeds: List<Embed>,
+)
+
+@Serializable
+data class Embed(
+    val servername: String,
+    val link: String,
+    val type: String,
+)

--- a/app/src/main/java/com/tanasi/streamflix/models/sololatino/SoloLatinoModels.kt
+++ b/app/src/main/java/com/tanasi/streamflix/models/sololatino/SoloLatinoModels.kt
@@ -1,0 +1,17 @@
+package com.tanasi.streamflix.models.sololatino
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Item(
+    val file_id: Int,
+    val video_language: String,
+    val sortedEmbeds: List<Embed>,
+)
+
+@Serializable
+data class Embed(
+    val servername: String,
+    val link: String,
+    val type: String,
+)

--- a/app/src/main/java/com/tanasi/streamflix/providers/AnimeBumProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/AnimeBumProvider.kt
@@ -1,0 +1,295 @@
+package com.tanasi.streamflix.providers
+
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.*
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import okhttp3.Cache
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Url
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+object AnimeBumProvider : Provider {
+
+    override val name = "AnimeBum"
+    override val baseUrl = "https://www.animebum.net"
+    override val language = "es"
+    override val logo = "$baseUrl/images/logo.png"
+
+    private val client = getOkHttpClient()
+
+    private val service = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .client(client)
+        .build()
+        .create(AnimeBumService::class.java)
+
+    private fun getOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .cache(Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024))
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .dns(
+                DnsOverHttps.Builder().client(OkHttpClient())
+                    .url("https://1.1.1.1/dns-query".toHttpUrl())
+                    .build()
+            )
+            .build()
+    }
+
+    private interface AnimeBumService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+    }
+
+    private fun parseShowsFromPage(document: Document): List<TvShow> {
+        return document.select("article.serie").mapNotNull {
+            val titleElement = it.selectFirst("div.title h3 a") ?: return@mapNotNull null
+            TvShow(
+                id = titleElement.attr("href"),
+                title = titleElement.attr("title"),
+                poster = it.selectFirst("figure.image img")?.attr("src")
+            )
+        }
+    }
+
+    private fun parseSearchShows(elements: List<Element>): List<AppAdapter.Item> {
+        return elements.mapNotNull { element ->
+            val urlElement = element.selectFirst("div.search-results__left a") ?: return@mapNotNull null
+            val title = element.selectFirst("div.search-results__left a h2")?.text() ?: ""
+            val poster = element.selectFirst("div.search-results__img a img")?.attr("src")
+            val overview = element.selectFirst("div.search-results__left div.description")?.text()
+            val type = element.selectFirst("div.search-results__left .result-type")?.text()
+
+            if (type == "Película") {
+                Movie(
+                    id = urlElement.attr("href"),
+                    title = title,
+                    poster = poster,
+                    overview = overview
+                )
+            } else {
+                TvShow(
+                    id = urlElement.attr("href"),
+                    title = title,
+                    poster = poster,
+                    overview = overview
+                )
+            }
+        }
+    }
+
+    override suspend fun getHome(): List<Category> {
+        return try {
+            coroutineScope {
+                val emisionDeferred = async { service.getPage("$baseUrl/emision") }
+                val latinoDeferred = async { service.getPage("$baseUrl/genero/audio-latino") }
+                val recientesDeferred = async { service.getPage("$baseUrl/series") }
+
+                val categories = mutableListOf<Category>()
+
+                val emisionShows = parseShowsFromPage(emisionDeferred.await())
+                if (emisionShows.isNotEmpty()) {
+                    val bannerShows = emisionShows.take(10).map { it.copy(banner = it.poster) }
+                    categories.add(Category(Category.FEATURED, bannerShows))
+                    categories.add(Category("En Emisión", emisionShows))
+                }
+
+                val latinoShows = parseShowsFromPage(latinoDeferred.await())
+                if (latinoShows.isNotEmpty()) {
+                    categories.add(Category("Audio Latino", latinoShows))
+                }
+
+                val recentShows = parseShowsFromPage(recientesDeferred.await())
+                if (recentShows.isNotEmpty()) {
+                    categories.add(Category("Series Recientes", recentShows))
+                }
+
+                categories
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre("genero/accion", "Acción"), Genre("genero/aventura", "Aventura"),
+                Genre("genero/ciencia-ficcion", "Ciencia Ficción"), Genre("genero/comedia", "Comedia"),
+                Genre("genero/deportes", "Deportes"), Genre("genero/demonios", "Demonios"),
+                Genre("genero/drama", "Drama"), Genre("genero/ecchi", "Ecchi"),
+                Genre("genero/escolares", "Escolares"), Genre("genero/fantasia", "Fantasía"),
+                Genre("genero/harem", "Harem"), Genre("genero/historico", "Histórico"),
+                Genre("genero/juegos", "Juegos"), Genre("genero/latino", "Latino"),
+                Genre("genero/lucha", "Lucha"), Genre("genero/magia", "Magia"),
+                Genre("genero/mecha", "Mecha"), Genre("genero/militar", "Militar"),
+                Genre("genero/misterio", "Misterio"), Genre("genero/musica", "Música"),
+                Genre("genero/parodia", "Parodia"), Genre("genero/policia", "Policía"),
+                Genre("genero/psicologico", "Psicológico"), Genre("genero/recuentos-de-la-vida", "Recuentos de la Vida"),
+                Genre("genero/romance", "Romance"), Genre("genero/samurai", "Samurái"),
+                Genre("genero/seinen", "Seinen"), Genre("genero/shoujo", "Shoujo"),
+                Genre("genero/shounen", "Shounen"), Genre("genero/sobrenatural", "Sobrenatural"),
+                Genre("genero/super-poderes", "Superpoderes"), Genre("genero/suspense", "Suspenso"),
+                Genre("genero/terror", "Terror"), Genre("genero/vampiros", "Vampiros"),
+                Genre("genero/yaoi", "Yaoi")
+            )
+        }
+        return try {
+            val document = service.getPage("$baseUrl/search?s=$query&page=$page")
+            parseSearchShows(document.select("div.search-results__item"))
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        return try {
+            val document = service.getPage("$baseUrl/peliculas?page=$page")
+            document.select("article.serie").mapNotNull {
+                val titleElement = it.selectFirst("div.title h3 a") ?: return@mapNotNull null
+                Movie(
+                    id = titleElement.attr("href"),
+                    title = titleElement.attr("title"),
+                    poster = it.selectFirst("figure.image img")?.attr("src")
+                )
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        return try {
+            val document = service.getPage("$baseUrl/series?page=$page")
+            parseShowsFromPage(document)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        return try {
+            val document = service.getPage("$baseUrl/$id?page=$page")
+            val shows = parseShowsFromPage(document)
+            val genreName = document.selectFirst("h1.main-title")?.text() ?: id.substringAfterLast("/")
+            Genre(id = id, name = genreName, shows = shows)
+        } catch (e: Exception) {
+            Genre(id = id, name = "Error", shows = emptyList())
+        }
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        return try {
+            val document = service.getPage(id)
+            val ratingPercent = document.selectFirst("div.Prct #A-circle")?.attr("data-percent")?.toDoubleOrNull()
+            Movie(
+                id = id,
+                title = document.selectFirst("h1.title-h1-serie")?.text()?.replace(" Online", "") ?: "",
+                poster = document.selectFirst("div.poster-serie img.poster-serie__img")?.attr("src"),
+                overview = document.selectFirst("div.description p")?.text(),
+                genres = document.select("div.boom-categories a").map {
+                    Genre(id = it.attr("href"), name = it.text())
+                },
+                released = document.selectFirst("p.datos-serie strong:contains(Año)")?.parent()?.text()?.substringAfter("Año:")?.trim(),
+                rating = ratingPercent?.let { it / 20.0 }
+            )
+        } catch (e: Exception) {
+            Movie(id = id, title = "Error al cargar")
+        }
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        return try {
+            val document = service.getPage(id)
+            val ratingPercent = document.selectFirst("div.Prct #A-circle")?.attr("data-percent")?.toDoubleOrNull()
+            val episodes = document.select("ul.list-episodies li").mapNotNull { element ->
+                val a = element.selectFirst("a") ?: return@mapNotNull null
+                val episodeTitle = a.ownText().trim()
+                val episodeNumber = Regex("""Episodio (\d+)""").find(episodeTitle)?.groupValues?.get(1)?.toIntOrNull()
+                Episode(
+                    id = a.attr("href"),
+                    number = episodeNumber ?: 0,
+                    title = episodeTitle
+                )
+            }
+
+            TvShow(
+                id = id,
+                title = document.selectFirst("h1.title-h1-serie")?.text()?.replace(" Online", "") ?: "",
+                poster = document.selectFirst("div.poster-serie img.poster-serie__img")?.attr("src"),
+                overview = document.selectFirst("div.description p")?.text(),
+                genres = document.select("div.boom-categories a").map {
+                    Genre(id = it.attr("href"), name = it.text())
+                },
+                released = document.selectFirst("p.datos-serie strong:contains(Año)")?.parent()?.text()?.substringAfter("Año:")?.trim(),
+                rating = ratingPercent?.let { it / 20.0 },
+                seasons = listOf(Season(id = id, number = 1, title = "Episodios", episodes = episodes))
+            )
+        } catch (e: Exception) {
+            TvShow(id = id, title = "Error al cargar")
+        }
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        return try {
+            getTvShow(seasonId).seasons.firstOrNull()?.episodes ?: emptyList()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        return try {
+            val url = when (videoType) {
+                is Video.Type.Movie -> {
+                    val moviePage = service.getPage(id)
+                    moviePage.selectFirst("ul.list-episodies li a")?.attr("href") ?: id
+                }
+                is Video.Type.Episode -> id
+            }
+
+            val document = service.getPage(url)
+            val scriptContent = document.selectFirst("script:containsData(var video = [])")?.data() ?: return emptyList()
+
+            val iframeRegex = """video\[\d+\]\s*=\s*['"]<iframe[^>]+src=["']([^"']+)["']""".toRegex()
+            iframeRegex.findAll(scriptContent).mapNotNull { matchResult ->
+                var videoUrl = matchResult.groupValues[1]
+                if (videoUrl.startsWith("//")) {
+                    videoUrl = "https:$videoUrl"
+                }
+
+                val serverName = try {
+                    videoUrl.toHttpUrl().host
+                        .replaceFirst("www.", "")
+                        .substringBefore(".")
+                        .replaceFirstChar { it.titlecase() }
+                } catch (e: Exception) {
+                    "Servidor"
+                }
+
+                Video.Server(id = videoUrl, name = serverName)
+            }.toList()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return Extractor.extract(server.id, server)
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw Exception("Esta función no está disponible en AnimeBum")
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/AnimeFlvProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/AnimeFlvProvider.kt
@@ -1,0 +1,408 @@
+package com.tanasi.streamflix.providers
+
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.*
+import com.tanasi.streamflix.models.animeflv.ServerModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.Cache
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import org.jsoup.nodes.Document
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+import retrofit2.http.Url
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+object AnimeFlvProvider : Provider {
+
+    override val name = "AnimeFLV"
+    override val baseUrl = "https://www3.animeflv.net"
+    override val language = "es"
+    override val logo = "https://www3.animeflv.net/assets/animeflv/img/logo.png"
+
+    private val client = getOkHttpClient()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .client(client)
+        .build()
+
+    private val service = retrofit.create(AnimeFlvService::class.java)
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+
+    private fun getOkHttpClient(): OkHttpClient {
+        val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
+
+        val clientBuilder = OkHttpClient.Builder()
+            .cache(appCache)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+
+        val dns = DnsOverHttps.Builder().client(clientBuilder.build())
+            .url("https://1.1.1.1/dns-query".toHttpUrl())
+            .build()
+
+        return clientBuilder.dns(dns).build()
+    }
+
+    private interface AnimeFlvService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+
+        @GET("browse")
+        suspend fun search(@Query("q") query: String, @Query("page") page: Int): Document
+
+        @GET("browse")
+        suspend fun getTvShows(@Query("order") order: String = "rating", @Query("page") page: Int): Document
+
+        @GET("browse")
+        suspend fun getMovies(@Query("type[]") type: String = "movie", @Query("page") page: Int): Document
+
+        @GET("browse")
+        suspend fun getGenre(@Query("genre[]") genre: String, @Query("page") page: Int): Document
+
+        @GET("anime/{id}")
+        suspend fun getShowDetails(@Path("id") id: String): Document
+    }
+
+    override suspend fun getHome(): List<Category> {
+        return try {
+            coroutineScope {
+                val homeDeferred = async { service.getPage(baseUrl) }
+                val addedDeferred = async { service.getPage("$baseUrl/browse?order=added&page=1") }
+                val airingDeferred = async { service.getPage("$baseUrl/browse?status[]=1&page=1") }
+
+                val categories = mutableListOf<Category>()
+
+                try {
+                    val addedDocument = addedDeferred.await()
+                    val bannerShows = addedDocument.select("ul.ListAnimes li article").mapNotNull { element ->
+                        val url = element.selectFirst("div.Description a.Button")?.attr("href") ?: return@mapNotNull null
+                        val posterUrl = element.selectFirst("a div.Image figure img")?.attr("src")
+                        val finalPoster = if (posterUrl?.startsWith("http") == true) posterUrl else posterUrl?.let { "$baseUrl$it" }
+
+                        TvShow(
+                            id = url.substringAfterLast("/"),
+                            title = element.selectFirst("a h3")?.text() ?: "",
+                            banner = finalPoster
+                        )
+                    }
+                    if (bannerShows.isNotEmpty()) {
+                        categories.add(Category(Category.FEATURED, bannerShows))
+                    }
+                } catch (e: Exception) { /* No-op */ }
+
+                try {
+                    val homeDocument = homeDeferred.await()
+                    val latestEpisodes = homeDocument.select("ul.ListEpisodios li")
+                        .mapNotNull { element ->
+                            val linkElement = element.selectFirst("a") ?: return@mapNotNull null
+                            val showUrl = linkElement.attr("href")
+                                .replace("/ver/", "/anime/")
+                                .substringBeforeLast("-")
+
+                            if (showUrl.isBlank()) return@mapNotNull null
+                            val imageUrl = element.selectFirst("span.Image img")?.attr("src")
+                            TvShow(
+                                id = showUrl.substringAfterLast("/"),
+                                title = element.selectFirst("strong.Title")?.text() ?: "",
+                                poster = imageUrl?.let { "$baseUrl$it" }?.replace("thumbs", "covers")
+                            )
+                        }
+                        .distinctBy { it.id }
+                    if (latestEpisodes.isNotEmpty()) {
+                        categories.add(Category("Últimos Episodios", latestEpisodes))
+                    }
+                } catch (e: Exception) { /* No-op */ }
+
+                try {
+                    val airingDocument = airingDeferred.await()
+                    val airingShows = airingDocument.select("ul.ListAnimes li article").mapNotNull { element ->
+                        val url = element.selectFirst("div.Description a.Button")?.attr("href") ?: return@mapNotNull null
+                        val posterUrl = element.selectFirst("a div.Image figure img")?.attr("src")
+                        val finalPoster = if (posterUrl?.startsWith("http") == true) posterUrl else posterUrl?.let { "$baseUrl$it" }
+
+                        TvShow(
+                            id = url.substringAfterLast("/"),
+                            title = element.selectFirst("a h3")?.text() ?: "",
+                            poster = finalPoster
+                        )
+                    }
+                    if (airingShows.isNotEmpty()) {
+                        categories.add(Category("Animes en Emisión", airingShows))
+                    }
+                } catch (e: Exception) { /* No-op */ }
+
+                return@coroutineScope categories
+            }
+        } catch (e: Exception) {
+            return emptyList()
+        }
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre("accion", "Acción"),
+                Genre("artes-marciales", "Artes Marciales"),
+                Genre("aventura", "Aventuras"),
+                Genre("carreras", "Carreras"),
+                Genre("ciencia-ficcion", "Ciencia Ficción"),
+                Genre("comedia", "Comedia"),
+                Genre("demencia", "Demencia"),
+                Genre("demonios", "Demonios"),
+                Genre("deportes", "Deportes"),
+                Genre("drama", "Drama"),
+                Genre("ecchi", "Ecchi"),
+                Genre("escolares", "Escolares"),
+                Genre("espacial", "Espacial"),
+                Genre("fantasia", "Fantasía"),
+                Genre("harem", "Harem"),
+                Genre("historico", "Histórico"),
+                Genre("infantil", "Infantil"),
+                Genre("josei", "Josei"),
+                Genre("juegos", "Juegos"),
+                Genre("magia", "Magia"),
+                Genre("mecha", "Mecha"),
+                Genre("militar", "Militar"),
+                Genre("misterio", "Misterio"),
+                Genre("musica", "Música"),
+                Genre("parodia", "Parodia"),
+                Genre("policia", "Policía"),
+                Genre("psicologico", "Psicológico"),
+                Genre("recuentos-de-la-vida", "Recuentos de la vida"),
+                Genre("romance", "Romance"),
+                Genre("samurai", "Samurai"),
+                Genre("seinen", "Seinen"),
+                Genre("shoujo", "Shojo"),
+                Genre("shounen", "Shounen"),
+                Genre("sobrenatural", "Sobrenatural"),
+                Genre("superpoderes", "Superpoderes"),
+                Genre("suspenso", "Suspenso"),
+                Genre("terror", "Terror"),
+                Genre("vampiros", "Vampiros"),
+                Genre("yaoi", "Yaoi"),
+                Genre("yuri", "Yuri")
+            )
+        }
+
+        return try {
+            if (page > 1) return emptyList()
+
+            val document = service.search(query, page)
+
+            document.select("ul.ListAnimes li article").mapNotNull { element ->
+                val url = element.selectFirst("div.Description a.Button")?.attr("href") ?: return@mapNotNull null
+                val id = url.substringAfterLast("/")
+                val title = element.selectFirst("a h3")?.text() ?: ""
+                val posterUrl = element.selectFirst("a div.Image figure img")?.attr("src")
+                val type = element.selectFirst("span.Type")?.text()
+
+                val finalPoster = if (posterUrl?.startsWith("http") == true) {
+                    posterUrl
+                } else {
+                    posterUrl?.let { "$baseUrl$it" }
+                }
+
+                if (type == "Película") {
+                    Movie(id = id, title = title, poster = finalPoster)
+                } else {
+                    TvShow(id = id, title = title, poster = finalPoster)
+                }
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        return try {
+            val document = service.getTvShows(page = page)
+            document.select("ul.ListAnimes li article").mapNotNull { element ->
+                val url = element.selectFirst("div.Description a.Button")?.attr("href") ?: return@mapNotNull null
+                val posterUrl = element.selectFirst("a div.Image figure img")?.attr("src")
+                val finalPoster = if (posterUrl?.startsWith("http") == true) posterUrl else posterUrl?.let { "$baseUrl$it" }
+
+                TvShow(
+                    id = url.substringAfterLast("/"),
+                    title = element.selectFirst("a h3")?.text() ?: "",
+                    poster = finalPoster
+                )
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        return try {
+            val document = service.getMovies(page = page)
+            document.select("ul.ListAnimes li article").mapNotNull { element ->
+                val url = element.selectFirst("div.Description a.Button")?.attr("href") ?: return@mapNotNull null
+                val posterUrl = element.selectFirst("a div.Image figure img")?.attr("src")
+                val finalPoster = if (posterUrl?.startsWith("http") == true) posterUrl else posterUrl?.let { "$baseUrl$it" }
+
+                Movie(
+                    id = url.substringAfterLast("/"),
+                    title = element.selectFirst("a h3")?.text() ?: "",
+                    poster = finalPoster
+                )
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        return try {
+            val document = service.getShowDetails(id)
+
+            val title = document.selectFirst("div.Ficha.fchlt div.Container .Title")?.text() ?: ""
+            val overview = document.selectFirst("div.Description")?.text()?.removeSurrounding("\"")
+            val poster = document.selectFirst("div.AnimeCover div.Image figure img")?.attr("src")
+            val genres = document.select("nav.Nvgnrs a").map {
+                Genre(id = it.attr("href").substringAfterLast("/"), name = it.text())
+            }
+
+            val script = document.select("script")
+                .firstOrNull { it.data().contains("var episodes =") }
+                ?.data() ?: ""
+
+            val episodesData = script.substringAfter("var episodes = [").substringBefore("];")
+            val animeUri = script.substringAfter("var anime_info = [").substringBefore("];")
+                .split(",")[2].replace("\"", "")
+
+            val episodes = episodesData.split("],[").mapNotNull {
+                val episodeNum = it.replace("[", "").replace("]", "").split(",")[0]
+                if (episodeNum.isNotBlank()) {
+                    Episode(
+                        id = "ver/$animeUri-$episodeNum",
+                        number = episodeNum.toIntOrNull() ?: 0,
+                        title = "Episodio $episodeNum"
+                    )
+                } else {
+                    null
+                }
+            }.reversed()
+
+            val seasons = listOf(
+                Season(
+                    id = id,
+                    number = 1,
+                    title = "Episodios",
+                    episodes = episodes
+                )
+            )
+
+            TvShow(
+                id = id,
+                title = title,
+                overview = overview,
+                poster = poster?.let { "$baseUrl$it" },
+                genres = genres,
+                seasons = seasons
+            )
+        } catch (e: Exception) {
+            TvShow(id = id, title = "Error al cargar")
+        }
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        val show = getTvShow(id)
+        return Movie(
+            id = show.id,
+            title = show.title,
+            overview = show.overview,
+            poster = show.poster,
+            genres = show.genres,
+            cast = emptyList(),
+            recommendations = emptyList()
+        )
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        val show = getTvShow(seasonId)
+        return show.seasons.firstOrNull()?.episodes ?: emptyList()
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        val genreName = id.replace("-", " ").replaceFirstChar { it.uppercase() }
+        return try {
+            val document = service.getGenre(genre = id, page = page)
+
+            val shows = document.select("ul.ListAnimes li article").mapNotNull { element ->
+                val url = element.selectFirst("div.Description a.Button")?.attr("href") ?: return@mapNotNull null
+                val showId = url.substringAfterLast("/")
+                val title = element.selectFirst("a h3")?.text() ?: ""
+                val posterUrl = element.selectFirst("a div.Image figure img")?.attr("src")
+                val type = element.selectFirst("span.Type")?.text()
+
+                val finalPoster = if (posterUrl?.startsWith("http") == true) posterUrl else posterUrl?.let { "$baseUrl$it" }
+
+                if (type == "Película") {
+                    Movie(id = showId, title = title, poster = finalPoster)
+                } else {
+                    TvShow(id = showId, title = title, poster = finalPoster)
+                }
+            }
+
+            Genre(id = id, name = genreName, shows = shows)
+        } catch (e: Exception) {
+            Genre(id = id, name = genreName, shows = emptyList())
+        }
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw Exception("Not implemented for this provider")
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        return try {
+            val url = when (videoType) {
+                is Video.Type.Movie -> {
+                    val movieDetailsPage = service.getPage("$baseUrl/anime/$id")
+                    val script = movieDetailsPage.selectFirst("script:containsData(var episodes =)")?.data() ?: return emptyList()
+                    val animeUri = script.substringAfter("var anime_info = [").substringBefore("];").split(",")[2].replace("\"", "")
+                    "$baseUrl/ver/$animeUri-1"
+                }
+                is Video.Type.Episode -> "$baseUrl/$id"
+            }
+
+            val document = service.getPage(url)
+            val script = document.selectFirst("script:containsData(var videos = {)")?.data() ?: return emptyList()
+            val jsonString = script.substringAfter("var videos =").substringBefore(";").trim()
+            val serverModel = json.decodeFromString<ServerModel>(jsonString)
+
+            serverModel.sub.mapNotNull { sub ->
+                if (sub.code.isNotBlank()) {
+                    Video.Server(
+                        id = sub.code,
+                        name = sub.title ?: "Servidor Desconocido"
+                    )
+                } else {
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return Extractor.extract(server.id, server)
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/AnimeIDProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/AnimeIDProvider.kt
@@ -1,0 +1,335 @@
+package com.tanasi.streamflix.providers
+
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.*
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Cache
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.dnsoverhttps.DnsOverHttps
+import org.jsoup.nodes.Document
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Url
+import java.io.File
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+object AnimeIDProvider : Provider {
+
+    override val name = "AnimeID"
+    override val baseUrl = "https://www.animeid.tv"
+    override val language = "es"
+    override val logo = "https://static.mocaverse.xyz/partner/5bfb09c5-9431-4745-852d-bb342a6d44d2-logo.png"
+
+    private val client = getOkHttpClient()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .client(client)
+        .build()
+
+    private val service = retrofit.create(AnimeIDService::class.java)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun getOkHttpClient(): OkHttpClient {
+        val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
+
+        val clientBuilder = OkHttpClient.Builder()
+            .cache(appCache)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+
+        val dns = DnsOverHttps.Builder().client(clientBuilder.build())
+            .url("https://1.1.1.1/dns-query".toHttpUrl())
+            .build()
+
+        return clientBuilder.dns(dns).build()
+    }
+
+    private interface AnimeIDService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+    }
+
+
+    override suspend fun getHome(): List<Category> {
+        return try {
+            coroutineScope {
+                val newestAnimesDeferred = async { service.getPage("$baseUrl/series?sort=newest&pag=1") }
+                val winter2024Deferred = async { service.getPage("$baseUrl/genero/invierno-2024") }
+                val fall2024Deferred = async { service.getPage("$baseUrl/genero/otono-2024") }
+
+                val newestAnimesDocument = newestAnimesDeferred.await()
+                val latestAnimes = parseTvShowsFromElements(newestAnimesDocument.select("#result article.item"))
+
+                val bannerShows = latestAnimes.map { it.copy(banner = it.poster) }
+
+                val categories = mutableListOf(
+                    Category(Category.FEATURED, bannerShows.take(5)),
+                    Category("Últimos Animes Agregados", latestAnimes)
+                )
+
+                try {
+                    val winter2024Document = winter2024Deferred.await()
+                    val winter2024Shows = parseTvShowsFromElements(winter2024Document.select("#result article.item"))
+                    categories.add(Category("Temporada Invierno 2024", winter2024Shows))
+                } catch (_: Exception) {}
+
+                try {
+                    val fall2024Document = fall2024Deferred.await()
+                    val fall2024Shows = parseTvShowsFromElements(fall2024Document.select("#result article.item"))
+                    categories.add(Category("Temporada Otoño 2024", fall2024Shows))
+                } catch (_: Exception) {}
+
+                categories
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre("accion", "Acción"), Genre("aventura", "Aventura"), Genre("carreras", "Carreras"),
+                Genre("ciencia-ficcion", "Ciencia Ficción"), Genre("comedia", "Comedia"),
+                Genre("deportes", "Deportes"), Genre("drama", "Drama"), Genre("escolares", "Escolares"),
+                Genre("fantasia", "Fantasía"), Genre("gore", "Gore"), Genre("harem", "Harem"),
+                Genre("historico", "Histórico"), Genre("horror", "Horror"), Genre("josei", "Josei"),
+                Genre("juegos", "Juegos"), Genre("magia", "Magia"), Genre("mecha", "Mecha"),
+                Genre("militar", "Militar"), Genre("misterio", "Misterio"), Genre("musica", "Música"),
+                Genre("parodia", "Parodia"), Genre("psicologico", "Psicológico"), Genre("romance", "Romance"),
+                Genre("seinen", "Seinen"), Genre("shojo", "Shōjo"), Genre("shonen", "Shōnen"),
+                Genre("sobrenatural", "Sobrenatural"), Genre("terror", "Terror"), Genre("vampiros", "Vampiros"),
+                Genre("yaoi", "Yaoi"), Genre("yuri", "Yuri")
+            )
+        }
+        val document = service.getPage("$baseUrl/buscar?q=$query&pag=$page")
+        return parseTvShowsFromElements(document.select("#result article.item"))
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        val document = service.getPage("$baseUrl/peliculas?pag=$page")
+        return parseMoviesFromElements(document.select("#result article.item"))
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        val document = service.getPage("$baseUrl/series?sort=views&pag=$page")
+        return parseTvShowsFromElements(document.select("#result article.item"))
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        val document = service.getPage(id)
+        val title = document.selectFirst("#anime section hgroup h1")?.text() ?: ""
+        val originalOverview = document.selectFirst("#anime section p.sinopsis")?.text()?.removeSurrounding("\"")
+
+        val newOverview = """
+            ${originalOverview ?: ""}
+
+            ----------------------------------------------------
+            NOTA DEL PROVEEDOR:
+            Esto parece ser una colección de películas. Para ver los servidores, por favor, use la función de búsqueda (la lupa 🔍) y busque "$title". Aparecerá como una serie y podrá seleccionar cada película individualmente.
+            ----------------------------------------------------
+        """.trimIndent()
+
+        return Movie(
+            id = id,
+            title = title,
+            poster = document.selectFirst("#anime figure img.cover")?.attr("src"),
+            overview = newOverview,
+            genres = document.select("#anime section ul.tags li a").map {
+                Genre(id = it.attr("href").substringAfterLast('/'), name = it.text())
+            },
+        )
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        val document = service.getPage(id)
+        val animeAjaxId = document.selectFirst("#ord")?.attr("data-id") ?: ""
+
+        val seasons = if (animeAjaxId.isNotEmpty()) {
+            listOf(
+                Season(
+                    id = "$animeAjaxId|S|$id", // ID Compuesto: "ID_AJAX|S|URL_REFERER"
+                    number = 1,
+                    title = "Episodios"
+                )
+            )
+        } else {
+            emptyList()
+        }
+
+        return TvShow(
+            id = id,
+            title = document.selectFirst("#anime section hgroup h1")?.text() ?: "",
+            poster = document.selectFirst("#anime figure img.cover")?.attr("src"),
+            overview = document.selectFirst("#anime section p.sinopsis")?.text()?.removeSurrounding("\""),
+            genres = document.select("#anime section ul.tags li a").map {
+                Genre(id = it.attr("href").substringAfterLast('/'), name = it.text())
+            },
+            seasons = seasons,
+        )
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        val (animeAjaxId, refererPath) = try {
+            val parts = seasonId.split("|S|")
+            parts[0] to parts[1]
+        } catch (e: Exception) {
+            return emptyList()
+        }
+        return getEpisodesFromAjax(animeAjaxId, baseUrl + refererPath)
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        return try {
+            val document = when (videoType) {
+                is Video.Type.Movie -> {
+                    val moviePage = service.getPage(id)
+                    val episodeUrl = moviePage.selectFirst("#listado li a")?.attr("href") ?: return emptyList()
+                    service.getPage(episodeUrl)
+                }
+                is Video.Type.Episode -> service.getPage(id)
+            }
+            parseServersFromPage(document)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return Extractor.extract(server.id, server)
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        val document = service.getPage("$baseUrl/genero/$id?pag=$page")
+        val shows = document.select("#result article.item").map { element ->
+            val href = element.selectFirst("a")?.attr("href") ?: ""
+            if (href.contains("/peliculas/")) {
+                parseMoviesFromElements(listOf(element)).first()
+            } else {
+                parseTvShowsFromElements(listOf(element)).first()
+            }
+        }
+        return Genre(
+            id = id,
+            name = id.replaceFirstChar { it.titlecase(Locale.ROOT) },
+            shows = shows
+        )
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw NotImplementedError("Este proveedor no soporta la búsqueda por persona.")
+    }
+
+
+    // Funciones de Ayuda (Helpers)
+
+    private fun parseTvShowsFromElements(elements: List<org.jsoup.nodes.Element>): List<TvShow> {
+        return elements.map { element ->
+            TvShow(
+                id = element.selectFirst("a")?.attr("href") ?: "",
+                title = element.selectFirst("a header")?.text() ?: "",
+                poster = element.selectFirst("a figure img")?.attr("src"),
+            )
+        }
+    }
+
+    private fun parseMoviesFromElements(elements: List<org.jsoup.nodes.Element>): List<Movie> {
+        return elements.map { element ->
+            Movie(
+                id = element.selectFirst("a")?.attr("href") ?: "",
+                title = element.selectFirst("a header")?.text() ?: "",
+                poster = element.selectFirst("a figure img")?.attr("src"),
+            )
+        }
+    }
+
+    private fun getEpisodesFromAjax(animeId: String, refererUrl: String): List<Episode> {
+        val episodeList = mutableListOf<Episode>()
+        var page = 1
+        var hasNextPage = true
+        while (hasNextPage) {
+            val ajaxUrl = "$baseUrl/ajax/caps?id=$animeId&ord=DESC&pag=$page"
+            val request = Request.Builder().url(ajaxUrl).get()
+                .addHeader("Referer", refererUrl)
+                .addHeader("X-Requested-With", "XMLHttpRequest")
+                .build()
+            val response = client.newCall(request).execute()
+            val responseBody = response.body?.string()
+            if (response.isSuccessful && !responseBody.isNullOrEmpty()) {
+                val episodesJson = json.decodeFromString<JsonObject>(responseBody)["list"]?.jsonArray
+                if (episodesJson.isNullOrEmpty()) {
+                    hasNextPage = false
+                } else {
+                    episodesJson.forEach { cap ->
+                        val capObject = cap.jsonObject
+                        val epNum = capObject["numero"]?.jsonPrimitive?.content ?: "0"
+                        episodeList.add(
+                            Episode(
+                                id = capObject["href"]?.jsonPrimitive?.content ?: "",
+                                number = epNum.toFloatOrNull()?.toInt() ?: 0,
+                                title = "Episodio $epNum"
+                            )
+                        )
+                    }
+                    page++
+                }
+            } else {
+                hasNextPage = false
+            }
+        }
+        return episodeList.reversed()
+    }
+
+    private fun parseServersFromPage(document: Document): List<Video.Server> {
+        return document.select("#partes div.container li.subtab div.parte").mapNotNull { script ->
+            val jsonString = script.attr("data")
+            val serverName = script.closest(".subtab")?.attr("data-tab-id")?.let { tabId ->
+                document.selectFirst("#mirrors [data-tab-id=\"$tabId\"]")?.ownText()?.trim()
+            } ?: "Unknown Server"
+            val jsonUnescaped = unescapeJava(jsonString).replace("\\", "")
+            val url = fetchUrls(jsonUnescaped).firstOrNull()?.replace("\\\\", "\\")
+            if (url != null) {
+                Video.Server(id = url, name = serverName)
+            } else {
+                null
+            }
+        }
+    }
+
+    private fun unescapeJava(escaped: String): String {
+        if (!escaped.contains("\\u")) return escaped
+        var processed = ""
+        var position = escaped.indexOf("\\u")
+        var tempEscaped = escaped
+        while (position != -1) {
+            if (position != 0) {
+                processed += tempEscaped.substring(0, position)
+            }
+            val token = tempEscaped.substring(position + 2, position + 6)
+            tempEscaped = tempEscaped.substring(position + 6)
+            processed += token.toInt(16).toChar()
+            position = tempEscaped.indexOf("\\u")
+        }
+        processed += tempEscaped
+        return processed
+    }
+
+    private fun fetchUrls(text: String): List<String> {
+        val linkRegex = "(http|ftp|https):\\/\\/([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])".toRegex()
+        return linkRegex.findAll(text).map { it.value.trim().removeSurrounding("\"") }.toList()
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/AnimefenixProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/AnimefenixProvider.kt
@@ -1,0 +1,277 @@
+package com.tanasi.streamflix.providers
+
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.*
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import okhttp3.Cache
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Url
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+object AnimefenixProvider : Provider {
+
+    override val name = "Animefenix"
+    override val baseUrl = "https://animefenix2.tv"
+    override val language = "es"
+    override val logo = "https://animefenix2.tv/themes/fenix-neo/images/AveFenix.png"
+
+    private val client = getOkHttpClient()
+
+    private val service = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .client(client)
+        .build()
+        .create(AnimefenixService::class.java)
+
+    private fun getOkHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .cache(Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024))
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .dns(
+                DnsOverHttps.Builder().client(OkHttpClient())
+                    .url("https://1.1.1.1/dns-query".toHttpUrl())
+                    .build()
+            )
+            .build()
+    }
+
+    private interface AnimefenixService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+    }
+
+    private fun parseShows(elements: List<Element>): List<TvShow> {
+        return elements.mapNotNull {
+            val a = it.selectFirst("a") ?: it
+            val titleElement = it.selectFirst("h3, p:not(.gray)")
+            val imageElement = it.selectFirst("img")
+
+            TvShow(
+                id = a.attr("href"),
+                title = titleElement?.text() ?: "",
+                poster = imageElement?.let { img ->
+                    img.attr("data-src").ifEmpty { img.attr("src") }
+                }
+            )
+        }
+    }
+
+    private fun parseMovies(elements: List<Element>): List<Movie> {
+        return elements.mapNotNull {
+            val a = it.selectFirst("a") ?: return@mapNotNull null
+            val posterElement = it.selectFirst(".main-img img")
+            Movie(
+                id = a.attr("href"),
+                title = it.selectFirst("p:not(.gray)")?.text() ?: "",
+                poster = posterElement?.attr("data-src")?.ifEmpty { posterElement.attr("src") }
+            )
+        }
+    }
+
+    override suspend fun getHome(): List<Category> {
+        return try {
+            coroutineScope {
+                val premieres2025Deferred = async { service.getPage("$baseUrl/directorio/anime?estreno=2025") }
+                val premieres2024Deferred = async { service.getPage("$baseUrl/directorio/anime?estreno=2024") }
+                val premieres2023Deferred = async { service.getPage("$baseUrl/directorio/anime?estreno=2023") }
+
+                val categories = mutableListOf<Category>()
+
+                try {
+                    val premieres2025Document = premieres2025Deferred.await()
+                    val bannerShows = parseShows(premieres2025Document.select(".grid-animes li article")).map {
+                        it.copy(banner = it.poster)
+                    }
+                    if (bannerShows.isNotEmpty()) {
+                        categories.add(Category(Category.FEATURED, bannerShows.take(10)))
+                    }
+                } catch (e: Exception) { /* No-op */ }
+
+                try {
+                    val premieres2024Document = premieres2024Deferred.await()
+                    val premieres2024Shows = parseShows(premieres2024Document.select(".grid-animes li article"))
+                    if (premieres2024Shows.isNotEmpty()) {
+                        categories.add(Category("Estrenos 2024", premieres2024Shows))
+                    }
+                } catch (e: Exception) { /* No-op */ }
+
+                try {
+                    val premieres2023Document = premieres2023Deferred.await()
+                    val premieres2023Shows = parseShows(premieres2023Document.select(".grid-animes li article"))
+                    if (premieres2023Shows.isNotEmpty()) {
+                        categories.add(Category("Estrenos 2023", premieres2023Shows))
+                    }
+                } catch (e: Exception) { /* No-op */ }
+
+                return@coroutineScope categories
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre("1", "Acción"), Genre("23", "Aventuras"), Genre("20", "Ciencia Ficción"),
+                Genre("5", "Comedia"), Genre("8", "Deportes"), Genre("38", "Demonios"),
+                Genre("6", "Drama"), Genre("11", "Ecchi"), Genre("2", "Escolares"),
+                Genre("13", "Fantasía"), Genre("28", "Harem"), Genre("24", "Historico"),
+                Genre("47", "Horror"), Genre("25", "Infantil"), Genre("51", "Isekai"),
+                Genre("29", "Josei"), Genre("14", "Magia"), Genre("26", "Artes Marciales"),
+                Genre("21", "Mecha"), Genre("22", "Militar"), Genre("17", "Misterio"),
+                Genre("36", "Música"), Genre("30", "Parodia"), Genre("31", "Policía"),
+                Genre("18", "Psicológico"), Genre("10", "Recuentos de la vida"), Genre("3", "Romance"),
+                Genre("34", "Samurai"), Genre("7", "Seinen"), Genre("4", "Shoujo"),
+                Genre("9", "Shounen"), Genre("12", "Sobrenatural"), Genre("15", "Superpoderes"),
+                Genre("19", "Suspenso"), Genre("27", "Terror"), Genre("39", "Vampiros"),
+                Genre("40", "Yaoi"), Genre("37", "Yuri")
+            )
+        }
+        return try {
+            val document = service.getPage("$baseUrl/directorio/anime?q=$query&p=$page")
+            parseShows(document.select(".grid-animes li article")).distinctBy { it.id }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        return try {
+            val document = service.getPage("$baseUrl/directorio/anime?p=$page")
+            parseShows(document.select(".grid-animes li article"))
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        return try {
+            val document = service.getPage("$baseUrl/directorio/anime?tipo=2&p=$page")
+            parseMovies(document.select(".grid-animes li article"))
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        return try {
+            val document = service.getPage("$baseUrl/directorio/anime?genero=$id&p=$page")
+            val shows = parseShows(document.select(".grid-animes li article"))
+            val genreName = document.selectFirst("h1.text-4xl")?.ownText()?.trim() ?: "Género"
+            Genre(id = id, name = genreName, shows = shows)
+        } catch (e: Exception) {
+            Genre(id = id, name = "Error", shows = emptyList())
+        }
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        return try {
+            val document = service.getPage(id)
+            val title = document.selectFirst("h1.text-4xl")?.ownText() ?: ""
+            val poster = document.selectFirst("#anime_image")?.let {
+                it.attr("data-src").ifEmpty { it.attr("src") }
+            }
+            val overview = document.selectFirst(".mb-6 p.text-gray-300")?.text()
+            val genres = document.select("a.bg-gray-800").map {
+                Genre(
+                    id = it.attr("href").substringAfterLast("/"),
+                    name = it.text()
+                )
+            }
+            Movie(id = id, title = title, poster = poster, overview = overview, genres = genres)
+        } catch (e: Exception) {
+            Movie(id = id, title = "Error al cargar")
+        }
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        return try {
+            val document = service.getPage(id)
+            val title = document.selectFirst("h1.text-4xl")?.ownText() ?: ""
+            val poster = document.selectFirst("#anime_image")?.let {
+                it.attr("data-src").ifEmpty { it.attr("src") }
+            }
+            val overview = document.selectFirst(".mb-6 p.text-gray-300")?.text()
+            val genres = document.select("a.bg-gray-800").map {
+                Genre(id = it.attr("href").substringAfterLast("/"), name = it.text())
+            }
+
+            val episodes = document.select(".divide-y li > a").mapNotNull { a ->
+                val titleEp = a.selectFirst(".font-semibold")?.text() ?: return@mapNotNull null
+                Episode(
+                    id = a.attr("href"),
+                    number = titleEp.substringAfter("Episodio ").toIntOrNull() ?: 0,
+                    title = titleEp
+                )
+            }.reversed()
+
+            TvShow(
+                id = id, title = title, poster = poster, overview = overview, genres = genres,
+                seasons = listOf(Season(id = id, number = 1, title = "Episodios", episodes = episodes))
+            )
+        } catch (e: Exception) {
+            TvShow(id = id, title = "Error al cargar")
+        }
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        return try {
+            getTvShow(seasonId).seasons.firstOrNull()?.episodes ?: emptyList()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        return try {
+            val url = if (videoType is Video.Type.Movie) {
+                val moviePage = service.getPage(id)
+                moviePage.selectFirst(".divide-y li > a")?.attr("href") ?: id
+            } else {
+                id
+            }
+
+            val document = service.getPage(url)
+            val script = document.selectFirst("script:containsData(var tabsArray)") ?: return emptyList()
+
+            script.data()
+                .substringAfter("<iframe").split("src='")
+                .drop(1)
+                .map { it.substringBefore("'").substringAfter("redirect.php?id=").trim() }
+                .mapNotNull { serverUrl ->
+                    try {
+                        val serverName = serverUrl.toHttpUrl().host
+                            .replaceFirst("www.", "")
+                            .substringBefore(".")
+                            .replaceFirstChar { it.titlecase() }
+                        Video.Server(id = serverUrl, name = serverName)
+                    } catch (e: Exception) {
+                        null
+                    }
+                }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return Extractor.extract(server.id, server)
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw Exception("Esta función no está disponible en AnimeFenix")
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/Cine24hProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/Cine24hProvider.kt
@@ -1,0 +1,285 @@
+package com.tanasi.streamflix.providers
+
+import android.util.Base64
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.Category
+import com.tanasi.streamflix.models.Episode
+import com.tanasi.streamflix.models.Genre
+import com.tanasi.streamflix.models.Movie
+import com.tanasi.streamflix.models.People
+import com.tanasi.streamflix.models.Season
+import com.tanasi.streamflix.models.Show
+import com.tanasi.streamflix.models.TvShow
+import com.tanasi.streamflix.models.Video
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import org.jsoup.nodes.Document
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Url
+import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
+
+object Cine24hProvider : Provider {
+
+    override val name = "Cine24h"
+    override val baseUrl = "https://cine24h.online"
+    override val language = "es"
+    override val logo = "https://i.ibb.co/kgjcsFmj/Image-1.png"
+
+    private val client = OkHttpClient.Builder()
+        .addInterceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36")
+                .build()
+            chain.proceed(request)
+        }
+        .readTimeout(30, TimeUnit.SECONDS)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    private val service = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .client(client)
+        .build()
+        .create(Cine24hService::class.java)
+
+    private interface Cine24hService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+    }
+
+    override suspend fun getHome(): List<Category> = coroutineScope {
+        val categories = mutableListOf<Category>()
+        val bannerDeferred = async { service.getPage("$baseUrl/release/2025/") }
+        val moviesDeferred = async { service.getPage("$baseUrl/estrenos/?type=movies") }
+        val tvShowsDeferred = async { service.getPage("$baseUrl/estrenos/?type=series") }
+
+        try {
+            val bannerShows = parseShows(bannerDeferred.await()).mapNotNull { show ->
+                when (show) {
+                    is Movie -> show.copy(poster = null, banner = show.poster)
+                    is TvShow -> show.copy(poster = null, banner = show.poster)
+                    else -> null
+                }
+            }
+            if (bannerShows.isNotEmpty()) {
+                categories.add(Category(Category.FEATURED, bannerShows.take(10)))
+            }
+        } catch (e: Exception) { /* Do nothing */ }
+
+        try {
+            val latestMovies = parseShows(moviesDeferred.await()).filterIsInstance<Movie>()
+            if (latestMovies.isNotEmpty()) {
+                categories.add(Category("Estrenos de Películas", latestMovies))
+            }
+        } catch (e: Exception) { /* Do nothing */ }
+
+        try {
+            val latestTvShows = parseShows(tvShowsDeferred.await()).filterIsInstance<TvShow>()
+            if (latestTvShows.isNotEmpty()) {
+                categories.add(Category("Estrenos de Series", latestTvShows))
+            }
+        } catch (e: Exception) { /* Do nothing */ }
+
+        categories
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre(id = "category/accion/", name = "Acción"),
+                Genre(id = "category/animacion/", name = "Animación"),
+                Genre(id = "category/anime/", name = "Anime"),
+                Genre(id = "category/aventura/", name = "Aventura"),
+                Genre(id = "category/belica/", name = "Bélica"),
+                Genre(id = "category/ciencia-ficcion/", name = "Ciencia ficción"),
+                Genre(id = "category/comedia/", name = "Comedia"),
+                Genre(id = "category/crimen/", name = "Crimen"),
+                Genre(id = "category/documental/", name = "Documental"),
+                Genre(id = "category/drama/", name = "Drama"),
+                Genre(id = "category/familia/", name = "Familia"),
+                Genre(id = "category/fantasia/", name = "Fantasía"),
+                Genre(id = "category/historia/", name = "Historia"),
+                Genre(id = "category/misterio/", name = "Misterio"),
+                Genre(id = "category/musica/", name = "Música"),
+                Genre(id = "category/romance/", name = "Romance"),
+                Genre(id = "category/suspense/", name = "Suspenso"),
+                Genre(id = "category/terror/", name = "Terror"),
+                Genre(id = "category/western/", name = "Western"),
+            )
+        }
+        val encodedQuery = URLEncoder.encode(query, "UTF-8")
+        val document = service.getPage("$baseUrl/?s=$encodedQuery&paged=$page")
+        return parseShows(document)
+    }
+
+    private fun parseShows(document: Document): List<AppAdapter.Item> {
+        val elements = document.select("main article.TPost, li.TPostMv article.TPost")
+        return elements.mapNotNull { article ->
+            val linkElement = article.selectFirst("a") ?: return@mapNotNull null
+            val url = linkElement.attr("href")
+            var title = linkElement.selectFirst("h2, .Title, .text-md")?.text()?.trim()
+            if (title.isNullOrEmpty()) return@mapNotNull null
+            val imageElement = linkElement.selectFirst(".Image img, figure img")
+            val posterUrl = imageElement?.attr("abs:src")?.ifEmpty { imageElement.attr("abs:data-src") } ?: ""
+
+            val lang = linkElement.selectFirst(".language-box .lang-item span")?.text()?.trim()
+            if (!lang.isNullOrEmpty()) {
+                title += " [$lang]"
+            }
+
+            when {
+                url.contains("/peliculas/") -> Movie(
+                    id = url.substringAfter("/peliculas/").removeSuffix("/"),
+                    title = title,
+                    poster = posterUrl.replace("/w185/", "/w300/").replace("/w92/", "/w300/")
+                )
+                url.contains("/series/") -> TvShow(
+                    id = url.substringAfter("/series/").removeSuffix("/"),
+                    title = title,
+                    poster = posterUrl.replace("/w185/", "/w300/").replace("/w92/", "/w300/")
+                )
+                else -> null
+            }
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        val document = service.getPage("$baseUrl/peliculas/page/$page")
+        return parseShows(document).filterIsInstance<Movie>()
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        val document = service.getPage("$baseUrl/series/page/$page")
+        return parseShows(document).filterIsInstance<TvShow>()
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        val document = service.getPage("$baseUrl/${id}page/$page")
+        val shows = parseShows(document).filterIsInstance<Show>()
+        val genreName = id.removePrefix("category/").removeSuffix("/").replaceFirstChar { it.uppercase() }
+        return Genre(id = id, name = genreName, shows = shows)
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        val document = service.getPage("$baseUrl/peliculas/$id")
+        val info = document.selectFirst(".TPost footer .Info")
+        return Movie(
+            id = id,
+            title = document.selectFirst(".TPost header .Title")?.text() ?: "",
+            overview = document.selectFirst(".TPost .Description")?.text(),
+            poster = document.selectFirst(".TPost .Image img")?.attr("abs:src")?.replace("/w185/", "/w500/"),
+            rating = info?.selectFirst(".Rank")?.text()?.toDoubleOrNull(),
+            released = info?.selectFirst(".Date")?.text(),
+            runtime = info?.selectFirst(".Time")?.text()
+                ?.replace("h", "")
+                ?.replace("m", "")
+                ?.trim()
+                ?.split(" ")
+                ?.let { (it.getOrNull(0)?.toIntOrNull() ?: 0) * 60 + (it.getOrNull(1)?.toIntOrNull() ?: 0) },
+            genres = document.select(".TPost .Description .Genre a")?.map {
+                Genre(id = it.attr("href"), name = it.text())
+            } ?: emptyList()
+        )
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        val document = service.getPage("$baseUrl/series/$id")
+        val info = document.selectFirst(".TPost footer .Info")
+        return TvShow(
+            id = id,
+            title = document.selectFirst(".TPost header .Title")?.text() ?: "",
+            overview = document.selectFirst(".TPost .Description")?.text(), // Corrected Selector
+            poster = document.selectFirst(".TPost .Image img")?.attr("abs:src")?.replace("/w185/", "/w500/"),
+            rating = info?.selectFirst(".Rank")?.text()?.toDoubleOrNull(),
+            released = info?.selectFirst(".Date")?.text(),
+            genres = document.select(".TPost .Description .Genre a")?.map {
+                Genre(id = it.attr("href"), name = it.text())
+            } ?: emptyList(),
+            seasons = document.select(".AABox").mapNotNull {
+                val seasonTitle = it.selectFirst(".Title")?.text() ?: return@mapNotNull null
+                val seasonNumber = Regex("""\d+$""").find(seasonTitle)?.value?.toIntOrNull() ?: return@mapNotNull null
+                Season(
+                    id = "$id/$seasonNumber",
+                    number = seasonNumber,
+                    title = seasonTitle
+                )
+            }.sortedByDescending { it.number }
+        )
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        val (showId, seasonNumber) = seasonId.split("/")
+        val document = service.getPage("$baseUrl/series/$showId")
+
+        val seasonBox = document.select(".AABox").find {
+            (it.selectFirst(".Title")?.text() ?: "").trim().endsWith(seasonNumber)
+        } ?: return emptyList()
+
+        return seasonBox.select(".TPTblCn tr").mapNotNull { row ->
+            val titleElement = row.selectFirst(".MvTbTtl a")
+            val episodeTitle = titleElement?.text()?.trim()
+            val episodeUrl = titleElement?.attr("abs:href")
+
+            if (episodeTitle.isNullOrEmpty() || episodeUrl.isNullOrEmpty()) {
+                return@mapNotNull null
+            }
+
+            Episode(
+                id = episodeUrl,
+                number = row.selectFirst(".Num")?.text()?.toIntOrNull() ?: 0,
+                title = episodeTitle,
+                poster = row.selectFirst(".MvTbImg img")?.attr("abs:src")?.replace("/w154/", "/w300/"),
+                released = row.selectFirst(".MvTbTtl span")?.text()
+            )
+        }.sortedBy { it.number }
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        val document = service.getPage(id)
+
+        return document.select("ul.optnslst li[data-src]").mapNotNull {
+            val serverInfo = it.selectFirst("button")?.text()?.replace(it.selectFirst(".nmopt")?.text() ?: "", "")?.trim() ?: ""
+            val encodedUrl = it.attr("data-src")
+            if (encodedUrl.isBlank()) return@mapNotNull null
+
+            val decodedUrl = try {
+                String(Base64.decode(encodedUrl, Base64.DEFAULT))
+            } catch (e: Exception) {
+                return@mapNotNull null
+            }
+
+            try {
+                val embedDocument = service.getPage(decodedUrl)
+                val finalUrl = embedDocument.selectFirst("iframe")?.attr("abs:src") ?: return@mapNotNull null
+
+                val serverName = finalUrl.toHttpUrl().host
+                    .replaceFirst("www.", "")
+                    .substringBefore(".")
+                    .replaceFirstChar { char -> if (char.isLowerCase()) char.titlecase() else char.toString() }
+
+                Video.Server(
+                    id = finalUrl,
+                    name = "$serverName ($serverInfo)",
+                    src = finalUrl
+                )
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return Extractor.extract(server.src, server)
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw Exception("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/CineCalidadProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/CineCalidadProvider.kt
@@ -1,0 +1,371 @@
+package com.tanasi.streamflix.providers
+
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.*
+import okhttp3.Cache
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import org.jsoup.nodes.Document
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Url
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+object CineCalidadProvider : Provider {
+
+    override val name = "CineCalidad"
+    override val baseUrl = "https://www.cinecalidad.ec"
+    override val language = "es"
+    override val logo = "https://www.cinecalidad.ec/wp-content/themes/Cinecalidad/assets/img/logo.png"
+
+    private fun getOkHttpClient(): OkHttpClient {
+        val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
+
+        val clientBuilder = OkHttpClient.Builder()
+            .cache(appCache)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+
+        val dns = DnsOverHttps.Builder().client(clientBuilder.build())
+            .url("https://1.1.1.1/dns-query".toHttpUrl())
+            .build()
+
+        return clientBuilder.dns(dns).build()
+    }
+
+    // Interfaz de servicio de Retrofit
+    private interface CineCalidadService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+    }
+
+    private val client = getOkHttpClient()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .client(client)
+        .build()
+
+    private val service = retrofit.create(CineCalidadService::class.java)
+
+    private fun parseShows(elements: List<org.jsoup.nodes.Element>): List<Show> {
+        return elements.mapNotNull { element ->
+            val a = element.selectFirst("a") ?: return@mapNotNull null
+            val href = a.attr("href")
+
+            val img = element.selectFirst("div.poster img") ?: return@mapNotNull null
+            val title = img.attr("alt")
+
+            // Priorizamos 'data-src' para imágenes de carga diferida (lazy load)
+            val posterUrl = img.attr("data-src").ifEmpty { img.attr("src") }
+
+            if (href.contains("/ver-pelicula/")) {
+                Movie(
+                    id = href,
+                    title = title,
+                    poster = posterUrl
+                )
+            } else if (href.contains("/ver-serie/")) {
+                TvShow(
+                    id = href,
+                    title = title,
+                    poster = posterUrl
+                )
+            } else {
+                null // Ignoramos otros elementos que no son ni película ni serie
+            }
+        }
+    }
+
+    override suspend fun getHome(): List<Category> {
+        return try {
+            coroutineScope {
+                // Lanzamos todas las peticiones de red en paralelo para máxima eficiencia
+                val mainPageDeferred = async { service.getPage(baseUrl) }
+                val actionPageDeferred = async { service.getPage("$baseUrl/genero-de-la-pelicula/accion/") }
+                val comedyPageDeferred = async { service.getPage("$baseUrl/genero-de-la-pelicula/comedia/") }
+
+                // Esperamos a que todas las peticiones terminen
+                val mainDocument = mainPageDeferred.await()
+                val actionDocument = actionPageDeferred.await()
+                val comedyDocument = comedyPageDeferred.await()
+
+                val categories = mutableListOf<Category>()
+
+                // 1. Usamos la sección "Destacadas" como nuestro banner/FEATURED
+                val featuredShows = mainDocument.select("aside#dtw_content_featured-3 li").mapNotNull {
+                    val a = it.selectFirst("a") ?: return@mapNotNull null
+                    val href = a.attr("href")
+                    val title = a.attr("title")
+                    // --- CORRECCIÓN AQUÍ ---
+                    // La imagen está en el estilo background-image de un span
+                    val imageUrl = a.selectFirst("img")?.attr("data-src")
+
+                    // Para la categoría FEATURED, usamos el campo 'banner' para que se vea más grande
+                    if (href.contains("/ver-pelicula/")) {
+                        Movie(id = href, title = title, banner = imageUrl)
+                    } else if (href.contains("/ver-serie/")) {
+                        TvShow(id = href, title = title, banner = imageUrl)
+                    } else {
+                        null
+                    }
+                }
+                if (featuredShows.isNotEmpty()) {
+                    categories.add(Category(Category.FEATURED, featuredShows))
+                }
+
+                // 2. Categoría de Últimos Estrenos (la que ya teníamos)
+                val latestReleases = parseShows(mainDocument.select("article.item[id^=post-]"))
+                if (latestReleases.isNotEmpty()) {
+                    categories.add(Category("Últimos Estrenos", latestReleases))
+                }
+
+                // 3. Categoría de Acción
+                val actionShows = parseShows(actionDocument.select("article.item[id^=post-]"))
+                if (actionShows.isNotEmpty()) {
+                    categories.add(Category("Acción", actionShows))
+                }
+
+                // 4. Categoría de Comedia
+                val comedyShows = parseShows(comedyDocument.select("article.item[id^=post-]"))
+                if (comedyShows.isNotEmpty()) {
+                    categories.add(Category("Comedia", comedyShows))
+                }
+
+                categories
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre(id = "genero-de-la-pelicula/accion", name = "Acción"),
+                Genre(id = "genero-de-la-pelicula/animacion", name = "Animación"),
+                Genre(id = "genero-de-la-pelicula/anime", name = "Anime"),
+                Genre(id = "genero-de-la-pelicula/aventura", name = "Aventura"),
+                Genre(id = "genero-de-la-pelicula/belica", name = "Bélico"),
+                Genre(id = "genero-de-la-pelicula/ciencia-ficcion", name = "Ciencia ficción"),
+                Genre(id = "genero-de-la-pelicula/crimen", name = "Crimen"),
+                Genre(id = "genero-de-la-pelicula/comedia", name = "Comedia"),
+                Genre(id = "genero-de-la-pelicula/documental", name = "Documental"),
+                Genre(id = "genero-de-la-pelicula/drama", name = "Drama"),
+                Genre(id = "genero-de-la-pelicula/familia", name = "Familiar"),
+                Genre(id = "genero-de-la-pelicula/fantasia", name = "Fantasía"),
+                Genre(id = "genero-de-la-pelicula/historia", name = "Historia"),
+                Genre(id = "genero-de-la-pelicula/musica", name = "Música"),
+                Genre(id = "genero-de-la-pelicula/misterio", name = "Misterio"),
+                Genre(id = "genero-de-la-pelicula/terror", name = "Terror"),
+                Genre(id = "genero-de-la-pelicula/suspense", name = "Suspenso"),
+                Genre(id = "genero-de-la-pelicula/romance", name = "Romance"),
+                Genre(id = "genero-de-la-pelicula/peliculas-de-dc-comics-online-cinecalidad", name = "Dc Comics"),
+                Genre(id = "genero-de-la-pelicula/universo-marvel", name = "Marvel")
+            )
+        }
+
+        return try {
+            val document = service.getPage("$baseUrl/page/$page?s=$query")
+            val searchResults = parseShows(document.select("article.item[id^=post-]"))
+            searchResults
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        return try {
+            // La página principal del sitio parece ser un listado de películas por defecto
+            val document = service.getPage("$baseUrl/page/$page")
+            parseShows(document.select("article.item[id^=post-]"))
+                .filterIsInstance<Movie>() // Nos quedamos solo con las películas
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        return try {
+            // Navegamos a la sección de series y paginamos
+            val document = service.getPage("$baseUrl/ver-serie/page/$page")
+            parseShows(document.select("article.item[id^=post-]"))
+                .filterIsInstance<TvShow>() // Nos quedamos solo con las series
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        val document = service.getPage(id)
+
+        val title = document.selectFirst("h1")?.text() ?: ""
+        val poster = document.selectFirst(".single_left table img")?.attr("data-src")
+
+        val detailsTd = document.selectFirst(".single_left td[style*=justify]")
+        val overview = detailsTd?.selectFirst("p:not(:has(span))")?.text()?.trim()
+
+        val rating = document.selectFirst("span:contains(TMDB) b")?.text()?.trim()?.toDoubleOrNull()
+
+        var genres: List<Genre> = emptyList()
+        var cast: List<People> = emptyList()
+
+        // Buscamos el párrafo que contiene los spans de detalles
+        val detailsParagraph = detailsTd?.selectFirst("p:has(span:contains(Género))")
+
+        // Iteramos sobre los spans dentro de ese párrafo
+        detailsParagraph?.children()?.forEach { span ->
+            val text = span.text()
+            if (text.startsWith("Género:")) {
+                genres = span.select("a").map { a -> Genre(id = a.attr("href"), name = a.text()) }
+            }
+            if (text.startsWith("Elenco:")) {
+                cast = span.select("a").map { a -> People(id = a.attr("href"), name = a.text()) }
+            }
+        }
+
+        return Movie(
+            id = id,
+            title = title,
+            poster = poster,
+            overview = overview,
+            rating = rating,
+            genres = genres,
+            cast = cast
+        )
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        val document = service.getPage(id)
+
+        val title = document.selectFirst("h1")?.text() ?: ""
+        val poster = document.selectFirst(".single_left table img")?.attr("data-src")
+
+        val detailsTd = document.selectFirst(".single_left td[style*=justify]")
+
+        // --- LÓGICA MEJORADA PARA LA DESCRIPCIÓN ---
+        // Buscamos el bloque de párrafos y encontramos el que contiene la descripción.
+        val overview = detailsTd?.select("p")?.find { p ->
+            p.hasText() && p.selectFirst("span") == null
+        }?.text()?.trim()
+
+        val rating = document.selectFirst("span:contains(TMDB) b")?.text()?.trim()?.toDoubleOrNull()
+
+        var genres: List<Genre> = emptyList()
+        var cast: List<People> = emptyList()
+
+        val detailsParagraph = detailsTd?.selectFirst("p:has(span:contains(Género))")
+        detailsParagraph?.children()?.forEach { span ->
+            val text = span.text()
+            if (text.startsWith("Género:")) {
+                genres = span.select("a").map { a -> Genre(id = a.attr("href"), name = a.text()) }
+            }
+            if (text.startsWith("Elenco:")) {
+                cast = span.select("a").map { a -> People(id = a.attr("href"), name = a.text()) }
+            }
+        }
+
+        val seasons = document.select(".mark-1 .numerando").mapNotNull {
+            it.text().substringAfter("S").substringBefore("-").toIntOrNull()
+        }.distinct().sorted().map { seasonNumber ->
+            Season(
+                id = "$id|$seasonNumber",
+                number = seasonNumber,
+                title = "Temporada $seasonNumber"
+            )
+        }
+
+        return TvShow(
+            id = id,
+            title = title,
+            poster = poster,
+            overview = overview,
+            rating = rating,
+            genres = genres,
+            cast = cast,
+            seasons = seasons
+        )
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        val (showId, seasonNumberStr) = seasonId.split('|')
+        val seasonNumber = seasonNumberStr.toIntOrNull() ?: 1
+
+        val document = service.getPage(showId)
+
+        return document.select(".mark-1").filter { element -> // 'it' ahora se llama 'element'
+            // Esta línea ahora debería ser más clara para el editor
+            element.selectFirst(".numerando")?.text()?.startsWith("S$seasonNumber-") == true
+        }.map { element -> // 'it' aquí también se llama 'element'
+            val a = element.selectFirst(".episodiotitle a")
+            val numerando = element.selectFirst(".numerando")?.text() ?: ""
+            val posterUrl = element.selectFirst("div.imagen img")?.attr("data-src")
+
+            val episodeNumber = numerando.substringAfter("-E").toIntOrNull() ?: 0
+            val episodeTitle = a?.text() ?: "Episodio $episodeNumber"
+
+            Episode(
+                id = a?.attr("href") ?: "",
+                number = episodeNumber,
+                title = episodeTitle,
+                poster = posterUrl
+            )
+        }.reversed()
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        return try {
+            // El 'id' que recibimos es la URL directa a la página del episodio o película.
+            val document = service.getPage(id)
+
+            document.select("#playeroptionsul li[data-option]")
+                .map { element ->
+                    val serverUrl = element.attr("data-option")
+                    // El nombre del servidor es el texto dentro de la etiqueta li.
+                    val serverName = element.text()
+
+                    Video.Server(
+                        id = serverUrl,
+                        name = serverName
+                    )
+                }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return Extractor.extract(server.id, server)
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        return try {
+            // El ID que guardamos es la ruta URL del género
+            val document = service.getPage("$baseUrl/$id/page/$page")
+
+            val shows = parseShows(document.select("article.item[id^=post-]"))
+            val genreName = id.substringAfterLast("/")
+                .replace("-", " ")
+                .replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+
+            Genre(
+                id = id,
+                name = genreName,
+                shows = shows
+            )
+        } catch (e: Exception) {
+            Genre(id = id, name = "Error", shows = emptyList())
+        }
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw Exception("getPeople not implemented")
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/FlixLatamProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/FlixLatamProvider.kt
@@ -1,0 +1,478 @@
+package com.tanasi.streamflix.providers
+
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.*
+import okhttp3.Cache
+import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.ResponseBody
+import okhttp3.dnsoverhttps.DnsOverHttps
+import org.jsoup.nodes.Document
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import retrofit2.http.Url
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import org.jsoup.nodes.Element
+import com.tanasi.streamflix.models.flixlatam.*
+import com.tanasi.streamflix.utils.CryptoAES
+import com.google.gson.Gson
+import android.util.Log
+import org.jsoup.Jsoup
+import retrofit2.http.HeaderMap
+
+object FlixLatamProvider : Provider {
+
+    override val name = "FlixLatam"
+    override val baseUrl = "https://flixlatam.com"
+    override val language = "es"
+
+    private val client = getOkHttpClient()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .addConverterFactory(GsonConverterFactory.create())
+        .client(client)
+        .build()
+
+    private val service = retrofit.create(FlixLatamService::class.java)
+
+    private fun getOkHttpClient(): OkHttpClient {
+        val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
+
+        val clientBuilder = OkHttpClient.Builder()
+            .cache(appCache)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+
+        val dns = DnsOverHttps.Builder().client(clientBuilder.build())
+            .url("https://1.1.1.1/dns-query".toHttpUrl())
+            .build()
+
+        return clientBuilder.dns(dns).build()
+    }
+
+    private interface FlixLatamService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+
+        @POST("/wp-admin/admin-ajax.php")
+        @Headers("x-requested-with: XMLHttpRequest")
+        suspend fun getPlayerAjax(@Body body: FormBody): ResponseBody
+
+        @POST("/wp-admin/admin-ajax.php")
+        @Headers("x-requested-with: XMLHttpRequest")
+        suspend fun getEpisodesAjax(@Body body: FormBody): ResponseBody
+
+        @GET
+        suspend fun getEmbedPage(
+            @Url url: String,
+            @HeaderMap headers: Map<String, String>
+        ): Document
+    }
+
+    private fun parseShows(elements: List<Element>): List<Show> {
+        return elements.mapNotNull {
+            val a = it.selectFirst("a") ?: return@mapNotNull null
+            val href = a.attr("href")
+
+            val title = it.selectFirst("h3")?.text()
+                ?: it.selectFirst(".title")?.text()
+                ?: return@mapNotNull null
+
+            // La imagen puede estar en 'src' o 'data-src'
+            val poster = it.selectFirst("img")?.let { img ->
+                img.attr("data-src").ifEmpty { img.attr("src") }
+            }
+
+            // El ID en DooPlay es la última parte de la URL (el "slug")
+            val id = href.removeSuffix("/").substringAfterLast("/")
+
+            when {
+                href.contains("/pelicula/") -> Movie(id = id, title = title, poster = poster)
+                href.contains("/serie/") -> TvShow(id = id, title = title, poster = poster)
+                else -> null
+            }
+        }
+    }
+
+    override suspend fun getHome(): List<Category> {
+        return try {
+            val document = service.getPage(baseUrl)
+            val categories = mutableListOf<Category>()
+
+            // 1. Banner / Destacados (FEATURED)
+            val featuredShows = document.select("#slider-movies-tvshows .item").mapNotNull {
+                val href = it.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+                val banner = it.selectFirst("img")?.attr("src")
+                val title = it.selectFirst(".data h3")?.text()
+                val id = href.removeSuffix("/").substringAfterLast("/")
+                val type = it.selectFirst("span.item_type")?.text()
+
+                if (type == "TV" || href.contains("/serie/")) {
+                    TvShow(id = id, title = title ?: "", banner = banner)
+                } else {
+                    Movie(id = id, title = title ?: "", banner = banner)
+                }
+            }
+            if (featuredShows.isNotEmpty()) {
+                categories.add(Category(Category.FEATURED, featuredShows))
+            }
+
+            // 2. TOP Películas (de la barra lateral)
+            val topMovies = document.select(".top-imdb-list.tleft .top-imdb-item").mapNotNull {
+                val a = it.selectFirst("a") ?: return@mapNotNull null
+                val href = a.attr("href")
+                val title = it.selectFirst(".title a")?.text() ?: return@mapNotNull null
+                val poster = it.selectFirst("img")?.attr("src")
+                val id = href.removeSuffix("/").substringAfterLast("/")
+                Movie(id = id, title = title, poster = poster)
+            }
+            if (topMovies.isNotEmpty()) {
+                categories.add(Category("TOP Películas", topMovies))
+            }
+
+            // 3. TOP Series (de la barra lateral)
+            val topTvShows = document.select(".top-imdb-list.tright .top-imdb-item").mapNotNull {
+                val a = it.selectFirst("a") ?: return@mapNotNull null
+                val href = a.attr("href")
+                val title = it.selectFirst(".title a")?.text() ?: return@mapNotNull null
+                val poster = it.selectFirst("img")?.attr("src")
+                val id = href.removeSuffix("/").substringAfterLast("/")
+                TvShow(id = id, title = title, poster = poster)
+            }
+            if (topTvShows.isNotEmpty()) {
+                categories.add(Category("TOP Series", topTvShows))
+            }
+
+            categories
+        } catch (e: Exception) {
+            Log.e("FLIXLATAM_ERROR", "Error en getHome", e)
+            emptyList()
+        }
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre(id = "accion", name = "Acción"),
+                Genre(id = "action-adventure", name = "Action & Adventure"),
+                Genre(id = "adolescencia", name = "Adolescencia"),
+                Genre(id = "animacion", name = "Animación"),
+                Genre(id = "anime", name = "Anime"),
+                Genre(id = "artes-marciales", name = "Artes Marciales"),
+                Genre(id = "aventura", name = "Aventura"),
+                Genre(id = "aventuras", name = "Aventuras"),
+                Genre(id = "belica", name = "Bélica"),
+                Genre(id = "belico", name = "Bélico"),
+                Genre(id = "ciencia-ficcion", name = "Ciencia Ficción"),
+                Genre(id = "comedia", name = "Comedia"),
+                Genre(id = "comedia-de-situacion", name = "Comedia de Situación"),
+                Genre(id = "crimen", name = "Crimen"),
+                Genre(id = "deporte", name = "Deporte"),
+                Genre(id = "dibujo-animado", name = "Dibujo Animado"),
+                Genre(id = "documental", name = "Documental"),
+                Genre(id = "drama", name = "Drama"),
+                Genre(id = "drama-adolescente", name = "Drama Adolescente"),
+                Genre(id = "drama-medico", name = "Drama Médico"),
+                Genre(id = "familia", name = "Familia"),
+                Genre(id = "fantasia", name = "Fantasía"),
+                Genre(id = "ficcion-historica", name = "Ficción Histórica"),
+                Genre(id = "historia", name = "Historia"),
+                Genre(id = "kids", name = "Kids"),
+                Genre(id = "misterio", name = "Misterio"),
+                Genre(id = "musica", name = "Música"),
+                Genre(id = "pelicula-de-tv", name = "Película de TV"),
+                Genre(id = "reality", name = "Reality"),
+                Genre(id = "romance", name = "Romance"),
+                Genre(id = "sci-fi-fantasy", name = "Sci-Fi & Fantasy"),
+                Genre(id = "soap", name = "Soap"),
+                Genre(id = "talk", name = "Talk"),
+                Genre(id = "telenovela", name = "Telenovela"),
+                Genre(id = "terror", name = "Terror"),
+                Genre(id = "war-politics", name = "War & Politics"),
+                Genre(id = "western", name = "Western"),
+            )
+        }
+        return try {
+            val document = service.getPage("$baseUrl/page/$page?s=$query")
+            // Usamos un selector genérico para los resultados de búsqueda de DooPlay
+            parseShows(document.select("div.search-page article, div.items article"))
+        } catch (e: Exception) {
+            Log.e("FLIXLATAM_ERROR", "Error in search", e)
+            emptyList()
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        return try {
+            val document = service.getPage("$baseUrl/pelicula/page/$page")
+            parseShows(document.select("div.items article"))
+                .filterIsInstance<Movie>()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        return try {
+            val document = service.getPage("$baseUrl/series/page/$page")
+            parseShows(document.select("div.items article"))
+                .filterIsInstance<TvShow>()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        return try {
+            val document = service.getPage("$baseUrl/genero/$id/page/$page")
+            val shows = parseShows(document.select("div.items article"))
+            val genreName = document.selectFirst("h1.Title")?.text() ?: id.replaceFirstChar { it.uppercase() }
+            Genre(
+                id = id,
+                name = genreName,
+                shows = shows
+            )
+        } catch (e: Exception) {
+            Genre(id = id, name = id.replaceFirstChar { it.uppercase() })
+        }
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw Exception("Esta función no está disponible en FlixLatam")
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        return try {
+            val document = service.getPage("$baseUrl/pelicula/$id/")
+
+            val title = document.selectFirst(".sheader .data h1")?.text() ?: ""
+            val poster = document.selectFirst(".sheader .poster img")?.attr("src")
+            val banner = document.selectFirst("style:containsData(background-image)")
+                ?.data()
+                ?.substringAfter("url(")
+                ?.substringBefore(")")
+
+            val overview = document.selectFirst("#info .wp-content p")?.text()
+            val rating = document.selectFirst(".dt_rating_data .dt_rating_vgs")?.text()?.toDoubleOrNull()
+            val released = document.selectFirst(".sheader .extra span.date")?.text()
+
+            val genres = document.select(".sgeneros a").map {
+                Genre(
+                    id = it.attr("href").removeSuffix("/").substringAfterLast("/"),
+                    name = it.text()
+                )
+            }
+
+            val cast = document.select("#cast .persons .person").map {
+                People(
+                    id = it.selectFirst("a")?.attr("href")?.removeSuffix("/")?.substringAfterLast("/") ?: "",
+                    name = it.selectFirst(".name a")?.text() ?: "",
+                    image = it.selectFirst(".img img")?.attr("src")
+                )
+            }
+
+            val recommendations = parseShows(document.select("#single_relacionados article"))
+
+            Movie(
+                id = id,
+                title = title,
+                poster = poster,
+                banner = banner,
+                overview = overview,
+                rating = rating,
+                released = released,
+                genres = genres,
+                cast = cast,
+                recommendations = recommendations
+            )
+        } catch (e: Exception) {
+            Log.e("FLIXLATAM_ERROR", "Error in getMovie", e)
+            Movie(id = id, title = "")
+        }
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        return try {
+            val document = service.getPage("$baseUrl/serie/$id/")
+
+            // ... (toda la extracción de title, poster, banner, etc., se queda igual)
+            val title = document.selectFirst(".sheader .data h1")?.text() ?: ""
+            val poster = document.selectFirst(".sheader .poster img")?.attr("src")
+            val banner = document.selectFirst("style:containsData(background-image)")
+                ?.data()
+                ?.substringAfter("url(")
+                ?.substringBefore(")")
+
+            val overview = document.selectFirst("#info .wp-content p")?.text()
+            val rating = document.selectFirst(".dt_rating_data .dt_rating_vgs")?.text()?.toDoubleOrNull()
+            val released = document.selectFirst(".sheader .extra span.date")?.text()
+
+            val genres = document.select(".sgeneros a").map {
+                Genre(
+                    id = it.attr("href").removeSuffix("/").substringAfterLast("/"),
+                    name = it.text()
+                )
+            }
+
+            val cast = document.select("#cast .persons .person").map {
+                People(
+                    id = it.selectFirst("a")?.attr("href")?.removeSuffix("/")?.substringAfterLast("/") ?: "",
+                    name = it.selectFirst(".name a")?.text() ?: "",
+                    image = it.selectFirst(".img img")?.attr("src")
+                )
+            }
+
+            val recommendations = parseShows(document.select("#single_relacionados article"))
+
+            val seasons = document.select("#seasons .se-c").mapNotNull { seasonElement ->
+                val seasonNumber = seasonElement.selectFirst(".se-q span.se-t")?.text()?.toIntOrNull() ?: return@mapNotNull null
+
+                val episodes = seasonElement.select(".se-a ul.episodios li").mapNotNull { episodeElement ->
+                    val a = episodeElement.selectFirst("a") ?: return@mapNotNull null
+                    val href = a.attr("href")
+                    val posterUrl = episodeElement.selectFirst(".imagen img")?.attr("src")
+                    val title = episodeElement.selectFirst(".episodiotitle a")?.text() ?: ""
+                    val numberStr = episodeElement.selectFirst(".numerando")?.text()
+                        ?.trim()?.split("-")?.getOrNull(1)?.trim()
+                    val number = numberStr?.toIntOrNull() ?: 0
+
+                    Episode(
+                        id = href.removeSuffix("/").substringAfterLast("/"),
+                        title = title,
+                        number = number,
+                        poster = posterUrl
+                    )
+                }
+
+                Season(
+                    id = "$id|$seasonNumber",
+                    number = seasonNumber,
+                    title = "Temporada $seasonNumber",
+                    episodes = episodes // <-- ¡CORREGIDO! Ya no se invierte la lista.
+                )
+            }
+
+            TvShow(
+                id = id,
+                title = title,
+                poster = poster,
+                banner = banner,
+                overview = overview,
+                rating = rating,
+                released = released,
+                genres = genres,
+                cast = cast,
+                recommendations = recommendations,
+                seasons = seasons
+            )
+        } catch (e: Exception) {
+            Log.e("FLIXLATAM_ERROR", "Error in getTvShow", e)
+            TvShow(id = id, title = "")
+        }
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        return try {
+            // seasonId ahora es "dragon-ball-daima|1"
+            val showId = seasonId.substringBefore("|")
+            val seasonNumber = seasonId.substringAfter("|").toInt()
+
+            // Re-obtenemos la información de la serie, que ya contiene todos los episodios.
+            val show = getTvShow(showId)
+
+            // Buscamos la temporada correcta y devolvemos sus episodios.
+            show.seasons.find { it.number == seasonNumber }?.episodes ?: emptyList()
+        } catch (e: Exception) {
+            Log.e("FLIXLATAM_ERROR", "Error in getEpisodesBySeason", e)
+            emptyList()
+        }
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        return try {
+            // Para las series, el 'id' del episodio no nos sirve. Necesitamos el de la serie.
+            // Afortunadamente, lo tenemos disponible en el objeto videoType.
+            val pageUrl = when (videoType) {
+                is Video.Type.Movie -> "$baseUrl/pelicula/$id/"
+                is Video.Type.Episode -> "$baseUrl/serie/${videoType.tvShow.id}/"
+            }
+            val document = service.getPage(pageUrl)
+
+            // Buscamos el ID del post, que es el que necesitamos para la llamada AJAX
+            val postId = document.body().className().substringAfter("postid-").substringBefore(" ")
+
+            // Para un episodio, necesitamos el 'data-nume' específico de ese episodio
+            val nume = when (videoType) {
+                is Video.Type.Movie -> "1" // Las películas suelen tener el nume "1"
+                is Video.Type.Episode -> {
+                    // Buscamos el episodio correcto en el HTML de la página de la serie
+                    document.selectFirst("#seasons .se-c .se-a li:contains(E${videoType.number})")
+                        ?.attr("data-id") ?: ""
+                }
+            }
+
+            if (postId.isBlank() || nume.isBlank()) {
+                return emptyList()
+            }
+
+            val body = FormBody.Builder()
+                .add("action", "doo_player_ajax")
+                .add("post", postId)
+                .add("nume", nume)
+                .add("type", if (videoType is Video.Type.Movie) "movie" else "tv")
+                .build()
+
+            val json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+            val playerResponseJson = service.getPlayerAjax(body).string()
+            val playerResponse = json.decodeFromString<PlayerResponse>(playerResponseJson)
+            val embedUrl = playerResponse.embed_url.replace("\\", "")
+
+            if (embedUrl.isBlank() || !embedUrl.contains("embed69")) return emptyList()
+
+            val embedHeaders = mapOf(
+                "Referer" to baseUrl,
+                "User-Agent" to "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+            )
+            val embedDocument = service.getEmbedPage(embedUrl, embedHeaders)
+
+            val dataLinkScript = embedDocument.selectFirst("script:containsData(const dataLink =)")?.data()
+            val dataLinkJsonString = Regex("""const dataLink\s*=\s*(\[.*?\]);""").find(dataLinkScript ?: "")?.groupValues?.get(1)
+                ?: return emptyList()
+
+            val dataLinkItems = json.decodeFromString<List<DataLinkItem>>(dataLinkJsonString)
+            dataLinkItems.flatMap { item ->
+                val language = item.video_language
+                item.sortedEmbeds.mapNotNull { embed ->
+                    val decryptedLink = CryptoAES.decrypt(embed.link, "Ak7qrvvH4WKYxV2OgaeHAEg2a5eh16vE")
+                    if (decryptedLink.isNotBlank()) {
+                        Video.Server(
+                            id = decryptedLink,
+                            name = "${embed.servername.replaceFirstChar { it.titlecase() }} [$language]"
+                        )
+                    } else {
+                        null
+                    }
+                }
+            }.distinctBy { it.id }
+        } catch (e: Exception) {
+            Log.e("FLIXLATAM_ERROR", "Error in getServers", e)
+            emptyList()
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video = Extractor.extract(server.id)
+
+    override val logo: String = "$baseUrl/wp-content/uploads/2022/04/cropped-Series-Latinoamerica.jpg"
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/OtakuversoProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/OtakuversoProvider.kt
@@ -1,0 +1,564 @@
+package com.tanasi.streamflix.providers
+
+import android.util.Log
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.Category
+import com.tanasi.streamflix.models.Episode
+import com.tanasi.streamflix.models.Genre
+import com.tanasi.streamflix.models.Movie
+import com.tanasi.streamflix.models.People
+import com.tanasi.streamflix.models.Season
+import com.tanasi.streamflix.models.TvShow
+import com.tanasi.streamflix.models.Show
+import com.tanasi.streamflix.models.Video
+import okhttp3.Cache
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.FormBody
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+import retrofit2.http.Url
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+
+
+object OtakuversoProvider : Provider {
+
+    override val name = "Otakuverso"
+    override val baseUrl = "https://otakuverso.net"
+    override val language = "es"
+    override val logo = "$baseUrl/logo.png"
+
+    private const val TAG = "OtakuversoProvider"
+
+    private val client = getOkHttpClient()
+
+    private val service = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .addConverterFactory(GsonConverterFactory.create())
+        .client(client)
+        .build()
+        .create(OtakuversoService::class.java)
+
+    private fun getOkHttpClient(): OkHttpClient {
+        val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
+
+        val clientBuilder = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36")
+                    .build()
+                chain.proceed(request)
+            }
+            .cache(appCache)
+            .cookieJar(object : CookieJar {
+                private val cookieStore = mutableMapOf<String, List<Cookie>>()
+                override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+                    cookieStore[url.host] = cookies
+                }
+                override fun loadForRequest(url: HttpUrl): List<Cookie> {
+                    return cookieStore[url.host] ?: emptyList()
+                }
+            })
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+
+        val dns = DnsOverHttps.Builder().client(clientBuilder.build())
+            .url("https://1.1.1.1/dns-query".toHttpUrl())
+            .build()
+
+        return clientBuilder.dns(dns).build()
+    }
+
+    private val genresList = listOf(
+        Genre("jR", "Aventura"),
+        Genre("k5", "Misterio"),
+        Genre("l5", "Shounen"),
+        Genre("mO", "Acción"),
+        Genre("nR", "Fantasía"),
+        Genre("oj", "Demonios"),
+        Genre("p2", "Histórico"),
+        Genre("q2", "Sobrenatural"),
+        Genre("rE", "Artes Marciales"),
+        Genre("vm", "Comedia"),
+        Genre("wR", "Superpoderes"),
+        Genre("x9", "Magia"),
+        Genre("y7", "Deportes"),
+        Genre("zY", "Drama"),
+        Genre("AO", "Escolares"),
+        Genre("BX", "Ciencia Ficción"),
+    )
+
+    private interface OtakuversoService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+
+        @GET("/animes")
+        suspend fun getAnimesPage(): Document
+
+        @GET("/buscador")
+        suspend fun search(
+            @Query("q") query: String,
+            @Query("page") page: Int
+        ): Document
+
+        @POST("/animes")
+        suspend fun getShowsByFilter(
+            @Body body: FormBody,
+            @Query("page") page: Int
+        ): Document
+
+        @GET("/play-video")
+        suspend fun getVideoEmbed(@Query("id") id: String): Document
+    }
+
+    private suspend fun getToken(): String {
+        val document = service.getAnimesPage()
+        val token = document.selectFirst("input[name=_token]")?.attr("value") ?: ""
+        Log.d(TAG, "Token CSRF obtenido: $token")
+        return token
+    }
+
+    override suspend fun getHome(): List<Category> {
+        val categories = mutableListOf<Category>()
+
+        coroutineScope {
+            // Hacemos las llamadas iniciales en paralelo
+            val estrenosDeferred = async { service.getPage("$baseUrl/estrenos") }
+            val popularDeferred = async {
+                val token = getToken()
+                val formBody = FormBody.Builder()
+                    .add("_token", token)
+                    .add("search_genero", "0")
+                    .add("search_anno", "0")
+                    .add("search_tipo", "0")
+                    .add("search_orden", "0")
+                    .add("search_estado", "0")
+                    .build()
+                service.getShowsByFilter(formBody, 1)
+            }
+
+            // Paso 1: Obtener la lista de estrenos para obtener los IDs
+            try {
+                val estrenosDocument = estrenosDeferred.await()
+                val estrenosListItems = parseShows(estrenosDocument)
+
+                // Paso 2: Obtener los detalles (incluyendo el banner) de los 5 primeros estrenos en paralelo
+                val featuredShowsDeferred = estrenosListItems.take(5).map { show ->
+                    async {
+                        try {
+                            // Esta llamada obtiene el banner de la página de detalles
+                            getTvShow(show.id)
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Error al obtener detalles para el show ${show.id}: ${e.message}", e)
+                            null
+                        }
+                    }
+                }
+
+                val featuredShows = featuredShowsDeferred.awaitAll().filterNotNull()
+                if (featuredShows.isNotEmpty()) {
+                    categories.add(Category(Category.FEATURED, featuredShows))
+                }
+
+            } catch (e: Exception) {
+                Log.e(TAG, "Error al obtener la lista de Estrenos: ${e.message}", e)
+            }
+
+            // Paso 3: Añadir el resto de categorías (Populares, etc.)
+            try {
+                val popularDocument = popularDeferred.await()
+                val popular = parseShows(popularDocument)
+                if (popular.isNotEmpty()) {
+                    categories.add(Category("Populares", popular))
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error al obtener Populares: ${e.message}", e)
+            }
+
+            // Aquí puedes dejar la sección de géneros si la habías añadido
+            val genreTasks = genresList.shuffled().take(3).map { genre ->
+                async {
+                    try {
+                        val token = getToken()
+                        val formBody = FormBody.Builder()
+                            .add("_token", token)
+                            .add("search_genero", genre.id)
+                            .add("search_anno", "0")
+                            .add("search_tipo", "0")
+                            .add("search_orden", "0")
+                            .add("search_estado", "0")
+                            .build()
+                        val document = service.getShowsByFilter(formBody, 1)
+                        val shows = parseShows(document)
+                        if (shows.isNotEmpty()) {
+                            Category(genre.name, shows)
+                        } else {
+                            null
+                        }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error al obtener género ${genre.name}: ${e.message}", e)
+                        null
+                    }
+                }
+            }
+            categories.addAll(genreTasks.awaitAll().filterNotNull())
+        }
+
+        return categories
+    }
+
+    // Nueva función auxiliar para el carrusel
+    private fun parseCarouselShows(document: Document): List<Show> {
+        return document.select("a.banner_link").mapNotNull { element ->
+            val link = element.attr("abs:href")
+            val title = element.selectFirst("h1")?.text().orEmpty()
+            val bannerUrl = element.selectFirst("img")?.attr("abs:src") ?: ""
+            val id = link.substringAfterLast("/")
+
+            if (title.isNotEmpty() && bannerUrl.isNotEmpty()) {
+                TvShow(
+                    id = id,
+                    title = title,
+                    banner = bannerUrl,
+                    poster = bannerUrl // Usar el banner como póster para el carrusel
+                )
+            } else {
+                null
+            }
+        }
+    }
+
+    private fun parseShows(document: Document): List<TvShow> {
+        val shows = document.select(".row [data-original-title]").mapNotNull { element ->
+            val link = element.selectFirst("a") ?: return@mapNotNull null
+            val title = element.selectFirst("p.font-GDSherpa-Bold")?.text().orEmpty()
+
+            // Selector más robusto para la imagen, buscando en múltiples lugares
+            val poster = element.selectFirst("img")?.attr("abs:src")
+                ?: element.selectFirst("img")?.attr("data-src")
+                ?: ""
+
+            val url = link.attr("abs:href")
+            val id = url.substringAfterLast("/")
+
+            TvShow(
+                id = id,
+                title = title,
+                poster = poster,
+            )
+        }
+        Log.d(TAG, "Shows parseados: ${shows.size}")
+        return shows
+    }
+
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return genresList // <-- Cambio aquí
+        }
+
+        try {
+            val document = service.search(query, page)
+            return parseShows(document)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error en search: ${e.message}", e)
+            return emptyList()
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        // Obtenemos los shows con tipo "2" (Películas) y los convertimos a objetos Movie
+        return getShows(page, "2").map { tvShow ->
+            Movie(
+                id = tvShow.id,
+                title = tvShow.title,
+                poster = tvShow.poster,
+            )
+        }
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        // Simplemente obtenemos los shows con tipo "1" (Series)
+        return getShows(page, "1")
+    }
+
+    private suspend fun getShows(page: Int, type: String): List<TvShow> {
+        try {
+            val token = getToken()
+            if (token.isEmpty()) {
+                throw Exception("No se pudo obtener el token CSRF.")
+            }
+
+            val formBody = FormBody.Builder()
+                .add("_token", token)
+                .add("search_genero", "0")
+                .add("search_anno", "0")
+                .add("search_tipo", type) // <-- Usamos el tipo que nos pasan
+                .add("search_orden", "0")
+                .add("search_estado", "0")
+                .build()
+
+            val document = service.getShowsByFilter(formBody, page)
+            return parseShows(document)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error en getShows (page: $page, type: $type): ${e.message}", e)
+            return emptyList()
+        }
+    }
+
+    // Reemplaza esta función completa en tu archivo
+    override suspend fun getMovie(id: String): Movie {
+        try {
+            val url = "$baseUrl/anime/$id"
+            val document = service.getPage(url)
+
+            val title = document.selectFirst("#back_data_perfil .inn-text h1")?.text().orEmpty()
+            val overview = document.selectFirst("#back_data_perfil .inn-text p.font14")?.ownText()
+
+            // El banner se encuentra en el meta tag de og:image
+            val banner = document.selectFirst("meta[property=og:image]")?.attr("content")
+
+            // El póster se encuentra en la URL que nos mencionaste, la cual es una imagen más cuadrada
+            val poster = document.selectFirst("div.img-in img[src*=storage/videos]")?.attr("abs:src")
+
+            val genres = document.select(".pre a[href*=/genero/]").map {
+                Genre(id = it.attr("href").substringAfterLast('/'), name = it.text())
+            }
+
+            val recommendations = document.select("h4:contains(También te puede interesar) + .row > div").mapNotNull { element ->
+                val link = element.selectFirst("a") ?: return@mapNotNull null
+                Movie(
+                    id = link.attr("href").substringAfterLast('/'),
+                    title = link.selectFirst(".font-GDSherpa-Bold")?.text().orEmpty(),
+                    poster = element.selectFirst("img")?.attr("abs:src")
+                )
+            }
+
+            return Movie(
+                id = id,
+                title = title,
+                overview = overview,
+                poster = poster,
+                banner = banner,
+                genres = genres,
+                recommendations = recommendations
+            )
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    // Reemplaza esta función completa en tu archivo
+    override suspend fun getTvShow(id: String): TvShow {
+        try {
+            val url = "$baseUrl/anime/$id"
+            val document = service.getPage(url)
+
+            val title = document.selectFirst("#back_data_perfil .inn-text h1")?.text().orEmpty()
+            val overview = document.selectFirst("#back_data_perfil .inn-text p.font14")?.ownText()
+
+            // El banner se encuentra en el meta tag de og:image
+            val banner = document.selectFirst("meta[property=og:image]")?.attr("content")
+
+            // El póster se encuentra en la URL que nos mencionaste, la cual es una imagen más cuadrada
+            val poster = document.selectFirst("div.img-in img[src*=storage/videos]")?.attr("abs:src")
+
+            val genres = document.select(".pre a[href*=/genero/]").map {
+                Genre(id = it.attr("href").substringAfterLast('/'), name = it.text())
+            }
+
+            val recommendations = document.select("h4:contains(También te puede interesar) + .row > div").mapNotNull { element ->
+                val link = element.selectFirst("a") ?: return@mapNotNull null
+                TvShow(
+                    id = link.attr("href").substringAfterLast('/'),
+                    title = link.selectFirst(".font-GDSherpa-Bold")?.text().orEmpty(),
+                    poster = element.selectFirst("img")?.attr("abs:src")
+                )
+            }
+
+            val seasonElements = document.select(".dropdown-menu a")
+            val seasons = if (seasonElements.isNotEmpty()) {
+                seasonElements.mapIndexed { index, element ->
+                    Season(
+                        id = element.attr("abs:href"),
+                        number = element.text().filter { it.isDigit() }.toIntOrNull() ?: (index + 1),
+                        title = element.text()
+                    )
+                }
+            } else {
+                listOf(Season(id = url, number = 1, title = "Temporada 1"))
+            }
+
+            return TvShow(
+                id = id,
+                title = title,
+                overview = overview,
+                poster = poster,
+                banner = banner,
+                genres = genres,
+                seasons = seasons.reversed(),
+                recommendations = recommendations
+            )
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        try {
+            // El seasonId que guardamos es la URL completa de la página de la temporada
+            val document = service.getPage(seasonId)
+
+            return document.select(".pl-lg-4 .container-fluid .row .col-6.text-center").map { element ->
+                val episodeLink = element.selectFirst(".font-GDSherpa-Bold a")
+                val episodeText = episodeLink?.text() ?: "Episodio"
+                val episodeNumber = episodeText.substringAfter("Episodio").trim().toIntOrNull() ?: 0
+
+                Episode(
+                    // La ID del episodio será su propia URL
+                    id = episodeLink?.attr("abs:href") ?: "",
+                    number = episodeNumber,
+                    title = episodeText,
+                    // El poster del episodio no está disponible en esta vista, se podría añadir más tarde si se encuentra
+                    poster = null,
+                    released = element.selectFirst(".font14 .bog")?.text()?.trim()
+                )
+            }.reversed() // La web los muestra del más nuevo al más antiguo
+        } catch (e: Exception) {
+            Log.e(TAG, "Error en getEpisodesBySeason (seasonId: $seasonId): ${e.message}", e)
+            return emptyList()
+        }
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        try {
+            val token = getToken()
+            if (token.isEmpty()) {
+                throw Exception("No se pudo obtener el token CSRF.")
+            }
+
+            val formBody = FormBody.Builder()
+                .add("_token", token)
+                .add("search_genero", id) // <-- Usamos el ID del género
+                .add("search_anno", "0")
+                .add("search_tipo", "0")
+                .add("search_orden", "0")
+                .add("search_estado", "0")
+                .build()
+
+            val document = service.getShowsByFilter(formBody, page)
+            val shows = parseShows(document)
+
+            // Buscamos el nombre del género en nuestra lista para devolver el objeto completo
+            val genreName = genresList.find { it.id == id }?.name ?: id.replaceFirstChar { it.uppercase() }
+
+            return Genre(id = id, name = genreName, shows = shows)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error en getGenre (id: $id, page: $page): ${e.message}", e)
+            return Genre(id = id, name = id, shows = emptyList())
+        }
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        return try {
+            val servers = mutableListOf<Video.Server>()
+            val episodeUrl: String = if (videoType is Video.Type.Movie) {
+                val moviePageUrl = "$baseUrl/anime/$id"
+                val movieDocument = service.getPage(moviePageUrl)
+
+                movieDocument.selectFirst("a[href*=/episodio-]")
+                    ?.attr("abs:href")
+                    ?: throw Exception("La película se encuentra buscando manualmente en Buscar.")
+            } else {
+                id
+            }
+
+            val episodeDocument = service.getPage(episodeUrl)
+
+            // 1. Extraemos el servidor de Filemoon (si está presente)
+            val mainIframe = episodeDocument.selectFirst("iframe#ytplayer")
+            if (mainIframe != null) {
+                val serverUrl = mainIframe.attr("src")
+                servers.add(Video.Server(id = serverUrl, name = "Filemoon"))
+            }
+
+            // 2. Extraemos los demás servidores del <select>
+            val serverOptions = episodeDocument.select("#ssel option")
+
+            for (option in serverOptions) {
+                val serverName = option.text()
+                val encodedValue = option.attr("value")
+
+                // Si el servidor es Filemoon, lo ignoramos para no duplicarlo,
+                // ya que lo extrajimos del iframe principal.
+                if (serverName.equals("Filemoon", ignoreCase = true)) {
+                    continue
+                }
+
+                // Aquí guardamos el valor codificado como ID para que getVideo() lo procese después.
+                servers.add(Video.Server(id = encodedValue, name = serverName))
+            }
+
+            if (servers.isEmpty()) {
+                throw Exception("No se encontraron servidores de video.")
+            }
+
+            servers
+        } catch (e: Exception) {
+            Log.e(TAG, "Error en getServers: ${e.message}", e)
+            emptyList()
+        }
+    }
+
+    // Nueva función auxiliar para decodificar los links de servidores
+    private suspend fun decodeServerUrl(encodedValue: String): String? {
+        return try {
+            // Hacemos una petición POST con el valor codificado para obtener el iframe
+            val document = service.getVideoEmbed(encodedValue)
+            document.selectFirst("iframe")?.attr("src")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error al decodificar URL del servidor: ${e.message}", e)
+            null
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return try {
+            val finalUrl = if (server.id.startsWith("http")) {
+                // Caso 1: Ya es una URL directa (como el iframe de Filemoon).
+                server.id
+            } else {
+                // Caso 2: Es un valor codificado, necesitamos decodificarlo.
+                decodeServerUrl(server.id)
+                    ?: throw Exception("No se pudo obtener la URL del video para el servidor: ${server.name}")
+            }
+
+            // Pasamos la URL final (sea directa o decodificada) al extractor.
+            Extractor.extract(finalUrl, server)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error en getVideo: ${e.message}", e)
+            throw e
+        }
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/PelisplustoProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/PelisplustoProvider.kt
@@ -316,7 +316,7 @@ object PelisplustoProvider : Provider {
             val servers = mutableListOf<Video.Server>()
             for (li in serverElements) {
                 try {
-                    val serverName = li.text()
+                    val serverName = li.text().replace(" Reproducir", "")
                     val dataServer = li.attr("data-server")
                     if (dataServer.isEmpty()) continue
 
@@ -337,14 +337,14 @@ object PelisplustoProvider : Provider {
                         servers.add(Video.Server(id = finalUrl, name = serverName, src = finalUrl))
                     }
                 } catch (e: Exception) {
-                    // Ignorar servidores individuales que fallen
+                    Log.e(TAG, "Fallo procesando un servidor individual: ${e.message}")
                 }
-                // <-- LA VACUNA ANTI-BOTS: Pausa de 300ms entre cada servidor
-                delay(300L)
+                delay(1500L)
             }
             return servers
 
         } catch (e: Exception) {
+            Log.e(TAG, "Fallo crítico en getServers: ${e.message}")
             return emptyList()
         }
     }

--- a/app/src/main/java/com/tanasi/streamflix/providers/PelisplustoProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/PelisplustoProvider.kt
@@ -1,0 +1,341 @@
+package com.tanasi.streamflix.providers
+
+import android.util.Base64
+import android.util.Log
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.Category
+import com.tanasi.streamflix.models.Episode
+import com.tanasi.streamflix.models.Genre
+import com.tanasi.streamflix.models.Movie
+import com.tanasi.streamflix.models.People
+import com.tanasi.streamflix.models.Season
+import com.tanasi.streamflix.models.Show
+import com.tanasi.streamflix.models.TvShow
+import com.tanasi.streamflix.models.Video
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import okhttp3.OkHttpClient
+import org.json.JSONObject
+import org.jsoup.nodes.Document
+import retrofit2.Retrofit
+import retrofit2.http.GET
+import retrofit2.http.Url
+import java.net.URLEncoder
+import java.util.concurrent.TimeUnit
+
+object PelisplustoProvider : Provider {
+
+    override val name = "Pelisplusto"
+    override val baseUrl = "https://pelisplus.to"
+    override val language = "es"
+    override val logo = "https://pelisplus.to/wp-content/uploads/2023/05/pelisplus-logo.png"
+    private const val TAG = "PelisplustoProvider"
+
+    private val client = OkHttpClient.Builder()
+        .addInterceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36")
+                .build()
+            chain.proceed(request)
+        }
+        .readTimeout(30, TimeUnit.SECONDS)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    private val service = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .client(client)
+        .build()
+        .create(PelisplustoService::class.java)
+
+    private interface PelisplustoService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+    }
+
+    override suspend fun getHome(): List<Category> = coroutineScope {
+        val categories = mutableListOf<Category>()
+
+        val mainPageDeferred = async { service.getPage(baseUrl) }
+        val moviesDeferred = async { service.getPage("$baseUrl/peliculas") }
+        val seriesDeferred = async { service.getPage("$baseUrl/series") }
+        val animesDeferred = async { service.getPage("$baseUrl/animes") }
+
+        try {
+            val mainDocument = mainPageDeferred.await()
+
+            // <-- ¡CORRECCIÓN! Este es el selector correcto para el carrusel de banners.
+            val bannerShows = mainDocument.select("div.home__slider_index div.swiper-slide article").mapNotNull {
+                val url = it.selectFirst("a")?.attr("href") ?: return@mapNotNull null
+
+                // La imagen del banner está en el 'div.bg' dentro de cada 'article'
+                val banner = it.selectFirst("div.bg")?.attr("style")
+                    ?.substringAfter("url(")?.substringBefore(")")
+                    ?.removeSurrounding("'")?.removeSurrounding("\"") ?: return@mapNotNull null
+
+                val title = it.selectFirst("h2")?.text()?.substringBefore(" (") ?: return@mapNotNull null
+                val id = url.substringAfterLast('/').removeSuffix("/")
+
+                when {
+                    url.contains("/pelicula/") -> Movie(id = id, title = title, banner = getAbsoluteUrl(banner))
+                    url.contains("/serie/") -> TvShow(id = id, title = title, banner = getAbsoluteUrl(banner))
+                    url.contains("/anime/") -> TvShow(id = "anime/$id", title = title, banner = getAbsoluteUrl(banner))
+                    else -> null
+                }
+            }
+            if (bannerShows.isNotEmpty()) {
+                categories.add(Category(Category.FEATURED, bannerShows))
+            }
+        } catch (e: Exception) { Log.e(TAG, "getHome (banners): ${e.message}") }
+
+        try {
+            val movies = parseShows(moviesDeferred.await()).filterIsInstance<Movie>()
+            if (movies.isNotEmpty()) categories.add(Category("Películas", movies))
+        } catch (e: Exception) { Log.e(TAG, "getHome (movies): ${e.message}") }
+
+        try {
+            val series = parseShows(seriesDeferred.await()).filterIsInstance<TvShow>()
+            if (series.isNotEmpty()) categories.add(Category("Series", series))
+        } catch (e: Exception) { Log.e(TAG, "getHome (series): ${e.message}") }
+
+        try {
+            val animes = parseShows(animesDeferred.await()).filterIsInstance<TvShow>()
+            if (animes.isNotEmpty()) categories.add(Category("Animes", animes))
+        } catch (e: Exception) { Log.e(TAG, "getHome (animes): ${e.message}") }
+
+        categories
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre("genero/accion", "Acción"),
+                Genre("genero/animacion", "Animación"),
+                Genre("genero/anime", "Anime"),
+                Genre("genero/aventura", "Aventura"),
+                Genre("genero/belica", "Bélica"),
+                Genre("genero/ciencia-ficcion", "Ciencia ficción"),
+                Genre("genero/comedia", "Comedia"),
+                Genre("genero/crimen", "Crimen"),
+                Genre("genero/documental", "Documental"),
+                Genre("genero/drama", "Drama"),
+                Genre("genero/familia", "Familia"),
+                Genre("genero/fantasia", "Fantasía"),
+                Genre("genero/guerra", "Guerra"),
+                Genre("genero/historia", "Historia"),
+                Genre("genero/misterio", "Misterio"),
+                Genre("genero/musica", "Música"),
+                Genre("genero/romance", "Romance"),
+                Genre("genero/suspense", "Suspenso"),
+                Genre("genero/terror", "Terror")
+            )
+        }
+
+        if (page > 1) {
+            return emptyList()
+        }
+
+        val encodedQuery = URLEncoder.encode(query, "UTF-8")
+        val url = "$baseUrl/search/$encodedQuery"
+        val document = service.getPage(url)
+        return parseShows(document)
+    }
+
+    private fun parseShows(document: Document): List<AppAdapter.Item> {
+        val elements = document.select("article.item.liste.relative a.itemA")
+
+        return elements.mapNotNull {
+            val url = it.attr("href")
+            val posterUrl = it.selectFirst("img")?.attr("data-src") ?: ""
+            val title = it.selectFirst("h2")?.text()?.substringBefore(" (") ?: return@mapNotNull null
+
+            when {
+                url.contains("/pelicula/") -> Movie(
+                    id = url.substringAfter("/pelicula/").removeSuffix("/"),
+                    title = title,
+                    poster = posterUrl
+                )
+                url.contains("/serie/") -> TvShow(
+                    id = url.substringAfter("/serie/").removeSuffix("/"),
+                    title = title,
+                    poster = posterUrl
+                )
+                url.contains("/anime/") -> TvShow(
+                    id = "anime/${url.substringAfter("/anime/").removeSuffix("/")}",
+                    title = title,
+                    poster = posterUrl
+                )
+                else -> null
+            }
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        val url = "$baseUrl/peliculas" + if (page > 1) "/page/$page" else ""
+        val document = service.getPage(url)
+        return parseShows(document).filterIsInstance<Movie>()
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        val url = "$baseUrl/series" + if (page > 1) "/page/$page" else ""
+        val document = service.getPage(url)
+        return parseShows(document).filterIsInstance<TvShow>()
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        val url = "$baseUrl/$id" + if (page > 1) "/page/$page" else ""
+        val document = service.getPage(url)
+        val shows = parseShows(document).filterIsInstance<Show>()
+        val genreName = id.substringAfter("genero/").replaceFirstChar { it.uppercase() }
+        return Genre(id = id, name = genreName, shows = shows)
+    }
+
+    private fun getAbsoluteUrl(url: String?): String? {
+        if (url.isNullOrEmpty()) return null
+        val cleanUrl = url.removePrefix("background-image: url(\"").removeSuffix("\");")
+        return if (cleanUrl.startsWith("http")) {
+            cleanUrl
+        } else {
+            "$baseUrl$cleanUrl"
+        }
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        val document = service.getPage("$baseUrl/pelicula/$id")
+        val info = document.selectFirst("div.genres.rating")
+        val posterUrl = document.selectFirst("meta[property=og:image]")?.attr("content")
+        val bannerUrl = document.selectFirst("div.bg")?.attr("style")
+            ?.substringAfter("url(")?.substringBefore(")")
+            ?.removeSurrounding("'")?.removeSurrounding("\"")
+
+        return Movie(
+            id = id,
+            title = document.selectFirst("h1.slugh1")?.text()?.substringBefore(" (") ?: "",
+            overview = document.selectFirst("div.description p")?.text(),
+            poster = getAbsoluteUrl(posterUrl),
+            banner = getAbsoluteUrl(bannerUrl),
+            rating = info?.select("span")?.find { it.text().contains("Rating:") }?.text()?.substringAfter(":")?.trim()?.toDoubleOrNull(),
+            released = info?.selectFirst("a")?.text(),
+            genres = document.select("div.genres")
+                .find { it.selectFirst("span b")?.text() == "Generos" }
+                ?.select("a")?.map {
+                    Genre(id = it.attr("href"), name = it.text())
+                } ?: emptyList()
+        )
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        val url = if (id.startsWith("anime/")) "$baseUrl/$id" else "$baseUrl/serie/$id"
+        val document = service.getPage(url)
+        val info = document.selectFirst("div.genres.rating")
+
+        val posterUrl = document.selectFirst("meta[property=og:image]")?.attr("content")
+        val bannerUrl = document.selectFirst("div.bg")?.attr("style")
+            ?.substringAfter("url(")?.substringBefore(")")
+            ?.removeSurrounding("'")?.removeSurrounding("\"")
+
+        val script = document.select("script").find { it.data().contains("seasonsJson") }?.data() ?: ""
+        val json = script.substringAfter("const seasonsJson = ").substringBefore(";")
+        val seasonsData = JSONObject(json)
+
+        return TvShow(
+            id = id,
+            title = document.selectFirst("h1.slugh1")?.text()?.substringBefore(" (") ?: "",
+            overview = document.selectFirst("div.description p")?.text(),
+            poster = getAbsoluteUrl(posterUrl),
+            banner = getAbsoluteUrl(bannerUrl),
+            rating = info?.select("span")?.find { it.text().contains("Rating:") }?.text()?.substringAfter(":")?.trim()?.toDoubleOrNull(),
+            released = info?.selectFirst("a")?.text(),
+            genres = document.select("div.genres")
+                .find { it.selectFirst("span b")?.text() == "Generos" }
+                ?.select("a")?.map {
+                    Genre(id = it.attr("href"), name = it.text())
+                } ?: emptyList(),
+            seasons = seasonsData.keys().asSequence().map {
+                val seasonNumber = it.toIntOrNull() ?: 0
+                Season(
+                    id = "$id/$seasonNumber",
+                    number = seasonNumber,
+                    title = "Temporada $seasonNumber"
+                )
+            }.sortedByDescending { it.number }.toList()
+        )
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        val lastSlashIndex = seasonId.lastIndexOf('/')
+        if (lastSlashIndex == -1) return emptyList()
+
+        val showId = seasonId.substring(0, lastSlashIndex)
+        val seasonNumber = seasonId.substring(lastSlashIndex + 1)
+
+        val url = if (showId.startsWith("anime/")) "$baseUrl/$showId" else "$baseUrl/serie/$showId"
+
+        try {
+            val document = service.getPage(url)
+            val script = document.select("script").find { it.data().contains("seasonsJson") }?.data() ?: ""
+            val json = script.substringAfter("const seasonsJson = ").substringBefore(";")
+            val seasonsData = JSONObject(json)
+            val episodesData = seasonsData.getJSONArray(seasonNumber)
+
+            return List(episodesData.length()) { i ->
+                val episodeData = episodesData.getJSONObject(i)
+                Episode(
+                    id = "$seasonId/${episodeData.getInt("episode")}",
+                    number = episodeData.getInt("episode"),
+                    title = episodeData.getString("title"),
+                    poster = "https://image.tmdb.org/t/p/w300${episodeData.getString("image")}"
+                )
+            }.sortedBy { it.number }
+        } catch (e: Exception) {
+            Log.e(TAG, "getEpisodesBySeason falló: ${e.message}")
+            return emptyList()
+        }
+    }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        val url = when (videoType) {
+            is Video.Type.Movie -> "$baseUrl/pelicula/${videoType.id}"
+            is Video.Type.Episode -> {
+                val showId = videoType.tvShow.id
+                val season = videoType.season.number
+                val episode = videoType.number
+
+                val basePath = if (showId.startsWith("anime/")) "$baseUrl/$showId" else "$baseUrl/serie/$showId"
+                "$basePath/season/$season/episode/$episode"
+            }
+        }
+
+        try {
+            val document = service.getPage(url)
+            return document.select(".bg-tabs ul li").mapNotNull { li ->
+                try {
+                    val serverName = li.text()
+                    val encodedData = li.attr("data-server")
+                    if (encodedData.isEmpty()) return@mapNotNull null
+                    val decodedUrl = String(Base64.decode(encodedData, Base64.DEFAULT))
+                    val finalUrl = if (decodedUrl.contains("/player/")) {
+                        val playerUrl = if (decodedUrl.startsWith("http")) decodedUrl else "$baseUrl$decodedUrl"
+                        val playerDoc = service.getPage(playerUrl)
+                        val scriptData = playerDoc.selectFirst("script:containsData(window.onload)")?.data() ?: ""
+                        Regex("""(https?://[^\s'"]+)""").find(scriptData)?.groupValues?.get(1) ?: return@mapNotNull null
+                    } else {
+                        decodedUrl
+                    }
+                    Video.Server(id = finalUrl, name = serverName, src = finalUrl)
+                } catch (e: Exception) { null }
+            }
+        } catch (e: Exception) { return emptyList() }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return Extractor.extract(server.src, server)
+    }
+
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw Exception("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/providers/PelisplustoProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/PelisplustoProvider.kt
@@ -68,7 +68,6 @@ object PelisplustoProvider : Provider {
         try {
             val mainDocument = mainPageDeferred.await()
 
-            // <-- ¡CORRECCIÓN! Este es el selector correcto para el carrusel de banners.
             val bannerShows = mainDocument.select("div.home__slider_index div.swiper-slide article").mapNotNull {
                 val url = it.selectFirst("a")?.attr("href") ?: return@mapNotNull null
 

--- a/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
@@ -65,6 +65,7 @@ interface Provider {
             AnimefenixProvider,
             AnimeFlvProvider,
             AnimeIDProvider,
+            SoloLatinoProvider,
         )
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
@@ -67,6 +67,7 @@ interface Provider {
             AnimeIDProvider,
             SoloLatinoProvider,
             Cine24hProvider,
+            PelisplustoProvider,
         )
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
@@ -64,11 +64,9 @@ interface Provider {
             AnimeBumProvider,
             AnimefenixProvider,
             AnimeFlvProvider,
-            AnimeIDProvider,
             SoloLatinoProvider,
             Cine24hProvider,
             PelisplustoProvider,
-            OtakuversoProvider,
         )
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
@@ -61,6 +61,10 @@ interface Provider {
             DoramasflixProvider,
             CineCalidadProvider,
             FlixLatamProvider,
+            AnimeBumProvider,
+            AnimefenixProvider,
+            AnimeFlvProvider,
+            AnimeIDProvider,
         )
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
@@ -66,6 +66,7 @@ interface Provider {
             AnimeFlvProvider,
             AnimeIDProvider,
             SoloLatinoProvider,
+            Cine24hProvider,
         )
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
@@ -59,6 +59,8 @@ interface Provider {
             CuevanaEuProvider,
             LatanimeProvider,
             DoramasflixProvider,
+            CineCalidadProvider,
+            FlixLatamProvider,
         )
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/Provider.kt
@@ -68,6 +68,7 @@ interface Provider {
             SoloLatinoProvider,
             Cine24hProvider,
             PelisplustoProvider,
+            OtakuversoProvider,
         )
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/providers/SoloLatinoProvider.kt
+++ b/app/src/main/java/com/tanasi/streamflix/providers/SoloLatinoProvider.kt
@@ -1,0 +1,490 @@
+package com.tanasi.streamflix.providers
+
+import android.util.Base64
+import com.tanasi.retrofit_jsoup.converter.JsoupConverterFactory
+import com.tanasi.streamflix.adapters.AppAdapter
+import com.tanasi.streamflix.extractors.Extractor
+import com.tanasi.streamflix.models.*
+import com.tanasi.streamflix.models.sololatino.Item
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.Cache
+import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import okhttp3.dnsoverhttps.DnsOverHttps
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Url
+import java.io.File
+import java.util.concurrent.TimeUnit
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import android.util.Log
+
+object SoloLatinoProvider : Provider {
+
+    override val name = "SoloLatino"
+    override val baseUrl = "https://sololatino.net"
+    override val language = "es"
+
+    private val client = getOkHttpClient()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .addConverterFactory(JsoupConverterFactory.create())
+        .client(client)
+        .build()
+
+    private val service = retrofit.create(SoloLatinoService::class.java)
+
+    private fun getOkHttpClient(): OkHttpClient {
+        val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
+
+        val clientBuilder = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36")
+                    .build()
+                chain.proceed(request)
+            }
+            .cache(appCache)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
+
+        val dns = DnsOverHttps.Builder().client(clientBuilder.build())
+            .url("https://1.1.1.1/dns-query".toHttpUrl())
+            .build()
+
+        return clientBuilder.dns(dns).build()
+    }
+
+    private interface SoloLatinoService {
+        @GET
+        suspend fun getPage(@Url url: String): Document
+
+        @POST("wp-admin/admin-ajax.php")
+        suspend fun getPlayerAjax(
+            @Header("Referer") referer: String,
+            @Body body: RequestBody
+        ): Response<ResponseBody>
+    }
+
+    override val logo = "$baseUrl/wp-content/uploads/2023/02/sololatino-logo-1.png"
+
+    override suspend fun getHome(): List<Category> = coroutineScope {
+        val categories = mutableListOf<Category>()
+
+        val deferredMap = mapOf(
+            "Tendencias" to async { service.getPage("$baseUrl/tendencias/page/1") },
+            "Películas de Estreno" to async { service.getPage("$baseUrl/pelicula/estrenos") },
+            "Series Mejor Valoradas" to async { service.getPage("$baseUrl/series/mejor-valoradas") },
+            "Animes Mejor Valorados" to async { service.getPage("$baseUrl/animes/mejor-valoradas") },
+            "Toons" to async { service.getPage("$baseUrl/genre_series/toons") },
+            "KDramas" to async { service.getPage("$baseUrl/genre_series/kdramas") }
+        )
+
+        // --- CORRECCIÓN AQUÍ ---
+        // El banner se crea a partir de "Tendencias" usando una función de parseo especial
+        try {
+            val trendingDoc = deferredMap["Tendencias"]?.await()
+            if (trendingDoc != null) {
+                // Usamos la nueva función parseBannerShows
+                val bannerShows = parseBannerShows(trendingDoc).take(12)
+                if (bannerShows.isNotEmpty()) {
+                    categories.add(Category(Category.FEATURED, bannerShows))
+                }
+            }
+        } catch (e: Exception) {
+            // No hacer nada si el banner falla
+        }
+
+        // Creamos el resto de las categorías
+        for ((categoryName, deferred) in deferredMap) {
+            try {
+                val doc = deferred.await()
+                // Usamos la función de parseo normal para las filas
+                val shows = parseShows(doc).take(12)
+                if (shows.isNotEmpty()) {
+                    categories.add(Category(categoryName, shows))
+                }
+            } catch (e: Exception) {
+                // Si una categoría falla, simplemente no se mostrará.
+            }
+        }
+
+        categories
+    }
+
+    // --- NUEVA FUNCIÓN PARA EL BANNER ---
+    private fun parseBannerShows(document: Document): List<Show> {
+        return document.select("article.item").map { element ->
+            val imageUrl = element.selectFirst("img")?.attr("data-srcset") ?: ""
+            val linkElement = element.selectFirst("a")!!
+            TvShow(
+                id = linkElement.attr("href"),
+                title = element.selectFirst("img")!!.attr("alt"),
+                // Asignamos la imagen a la propiedad 'banner'
+                banner = if (imageUrl.startsWith("http")) imageUrl else "$baseUrl$imageUrl"
+            )
+        }
+    }
+
+    // Funciones de ayuda para las filas (sin cambios)
+    private fun parseShows(document: Document): List<Show> {
+        return document.select("article.item").map { element ->
+            val posterUrl = element.selectFirst("img")?.attr("data-srcset") ?: ""
+            val linkElement = element.selectFirst("a")!!
+            TvShow(
+                id = linkElement.attr("href"),
+                title = element.selectFirst("img")!!.attr("alt"),
+                poster = if (posterUrl.startsWith("http")) posterUrl else "$baseUrl$posterUrl"
+            )
+        }
+    }
+
+    private fun parseMovies(document: Document): List<Movie> {
+        return document.select("article.item").map { element ->
+            val posterUrl = element.selectFirst("img")?.attr("data-srcset") ?: ""
+            val linkElement = element.selectFirst("a")!!
+            Movie(
+                id = linkElement.attr("href"),
+                title = element.selectFirst("img")!!.attr("alt"),
+                poster = if (posterUrl.startsWith("http")) posterUrl else "$baseUrl$posterUrl"
+            )
+        }
+    }
+
+    private fun parseTvShows(document: Document): List<TvShow> {
+        return document.select("article.item").map { element ->
+            val posterUrl = element.selectFirst("img")?.attr("data-srcset") ?: ""
+            val linkElement = element.selectFirst("a")!!
+            TvShow(
+                id = linkElement.attr("href"),
+                title = element.selectFirst("img")!!.attr("alt"),
+                poster = if (posterUrl.startsWith("http")) posterUrl else "$baseUrl$posterUrl"
+            )
+        }
+    }
+
+    override suspend fun search(query: String, page: Int): List<AppAdapter.Item> {
+        if (query.isBlank()) {
+            return listOf(
+                Genre("accion", "Acción"),
+                Genre("action-adventure", "Action & Adventure"),
+                Genre("animacion", "Animación"),
+                Genre("aventura", "Aventura"),
+                Genre("belica", "Bélica"),
+                Genre("ciencia-ficcion", "Ciencia Ficción"),
+                Genre("comedia", "Comedia"),
+                Genre("crimen", "Crimen"),
+                Genre("disney", "Disney"),
+                Genre("documental", "Documental"),
+                Genre("drama", "Drama"),
+                Genre("familia", "Familia"),
+                Genre("fantasia", "Fantasía"),
+                Genre("hbo", "HBO"),
+                Genre("historia", "Historia"),
+                Genre("kids", "Kids"),
+                Genre("misterio", "Misterio"),
+                Genre("musica", "Música"),
+                Genre("romance", "Romance"),
+                Genre("sci-fi-fantasy", "Sci-Fi & Fantasy"),
+                Genre("soap", "Soap"),
+                Genre("suspense", "Suspense"),
+                Genre("talk", "Talk"),
+                Genre("terror", "Terror"),
+                Genre("war-politics", "War & Politics"),
+                Genre("western", "Western"),
+            )
+        }
+
+        return try {
+            val document = service.getPage("$baseUrl/page/$page?s=$query")
+            parseShows(document)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getMovies(page: Int): List<Movie> {
+        return try {
+            val document = service.getPage("$baseUrl/pelicula/estrenos/page/$page")
+            parseMovies(document)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getTvShows(page: Int): List<TvShow> {
+        return try {
+            val document = service.getPage("$baseUrl/series/page/$page")
+            parseTvShows(document)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun getGenre(id: String, page: Int): Genre {
+        return try {
+            val document = service.getPage("$baseUrl/page/$page?s=$id")
+            val shows = parseShows(document)
+            Genre(
+                id = id,
+                name = id.replaceFirstChar { it.uppercase() },
+                shows = shows
+            )
+        } catch (e: Exception) {
+            Genre(id = id, name = id.replaceFirstChar { it.uppercase() }, shows = emptyList())
+        }
+    }
+
+    override suspend fun getMovie(id: String): Movie {
+        return try {
+            val document = service.getPage(id)
+
+            val sheader = document.selectFirst("div.sheader")!!
+            val posterUrl = sheader.selectFirst("div.poster > img")?.attr("src") ?: ""
+            val title = sheader.selectFirst("div.data > h1")?.text() ?: "Sin Título"
+            val genres = sheader.select("div.data > div.sgeneros > a").map {
+                Genre(
+                    id = it.attr("href").substringAfter("/genres/").removeSuffix("/"),
+                    name = it.text()
+                )
+            }
+            val overview = document.selectFirst("div.wp-content > p")?.text()
+
+            // New data extraction
+            val banner = document.selectFirst("div.wallpaper")
+                ?.attr("style")
+                ?.substringAfter("url(")?.substringBefore(")")
+            val rating = document.selectFirst("div.nota > span")?.text()
+                ?.substringBefore(" ")?.toDoubleOrNull()
+            val extraInfo = document.selectFirst("div.sbox.extra")
+            val runtime = extraInfo?.selectFirst("span.runtime")?.text()
+                ?.removeSuffix(" Min.")?.trim()?.toIntOrNull()
+            val released = sheader.selectFirst("span.date")?.text()
+                ?.split(", ")?.getOrNull(1)
+            val trailer = extraInfo?.selectFirst("li > span > a[href*=youtube]")
+                ?.attr("href")
+
+            val cast = document.select("div.sbox.srepart > div.persons > div.person").map {
+                People(
+                    id = it.selectFirst("a")?.attr("href") ?: "",
+                    name = it.selectFirst(".name a")?.text() ?: "",
+                    image = it.selectFirst(".img img")?.attr("src")
+                )
+            }
+
+            val recommendations = document.select("div.sbox.srelacionados article").map {
+                val recPoster = it.selectFirst("img")?.attr("data-srcset") ?: ""
+                TvShow(
+                    id = it.selectFirst("a")!!.attr("href"),
+                    title = it.selectFirst("img")!!.attr("alt"),
+                    poster = if (recPoster.startsWith("http")) recPoster else "$baseUrl$recPoster"
+                )
+            }
+
+            Movie(
+                id = id,
+                title = title,
+                poster = if (posterUrl.startsWith("http")) posterUrl else "$baseUrl$posterUrl",
+                banner = banner,
+                genres = genres,
+                overview = overview,
+                rating = rating,
+                runtime = runtime,
+                released = released,
+                trailer = trailer,
+                cast = cast,
+                recommendations = recommendations,
+            )
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    override suspend fun getTvShow(id: String): TvShow {
+        return try {
+            val document = service.getPage(id)
+
+            val sheader = document.selectFirst("div.sheader")!!
+            val posterUrl = sheader.selectFirst("div.poster > img")?.attr("src") ?: ""
+            val title = sheader.selectFirst("div.data > h1")?.text() ?: "Sin Título"
+            val genres = sheader.select("div.data > div.sgeneros > a").map {
+                Genre(
+                    id = it.attr("href").substringAfter("/genres/").removeSuffix("/"),
+                    name = it.text()
+                )
+            }
+            val overview = document.selectFirst("div.wp-content > p")?.text()
+
+            val seasons = document.select("div#seasons div.se-c").map { seasonElement ->
+                val seasonNumber = seasonElement.attr("data-season").toIntOrNull() ?: 0
+                Season(
+                    id = "$id@$seasonNumber",
+                    number = seasonNumber,
+                    title = "Temporada $seasonNumber"
+                )
+            }.filter { it.number != 0 }
+
+            // New data extraction
+            val banner = document.selectFirst("div.wallpaper")
+                ?.attr("style")
+                ?.substringAfter("url(")?.substringBefore(")")
+            val rating = document.selectFirst("div.nota > span")?.text()
+                ?.substringBefore(" ")?.toDoubleOrNull()
+            val extraInfo = document.selectFirst("div.sbox.extra")
+            val runtime = extraInfo?.selectFirst("span.runtime")?.text()
+                ?.removeSuffix(" Min.")?.trim()?.toIntOrNull()
+            val released = sheader.selectFirst("span.date")?.text()
+                ?.split(", ")?.getOrNull(1)
+            val trailer = extraInfo?.selectFirst("li > span > a[href*=youtube]")
+                ?.attr("href")
+
+            val cast = document.select("div.sbox.srepart > div.persons > div.person").map {
+                People(
+                    id = it.selectFirst("a")?.attr("href") ?: "",
+                    name = it.selectFirst(".name a")?.text() ?: "",
+                    image = it.selectFirst(".img img")?.attr("src")
+                )
+            }
+
+            val recommendations = document.select("div.sbox.srelacionados article").map {
+                val recPoster = it.selectFirst("img")?.attr("data-srcset") ?: ""
+                TvShow(
+                    id = it.selectFirst("a")!!.attr("href"),
+                    title = it.selectFirst("img")!!.attr("alt"),
+                    poster = if (recPoster.startsWith("http")) recPoster else "$baseUrl$recPoster"
+                )
+            }
+
+            TvShow(
+                id = id,
+                title = title,
+                poster = if (posterUrl.startsWith("http")) posterUrl else "$baseUrl$posterUrl",
+                banner = banner,
+                genres = genres,
+                overview = overview,
+                seasons = seasons.reversed(),
+                rating = rating,
+                runtime = runtime,
+                released = released,
+                trailer = trailer,
+                cast = cast,
+                recommendations = recommendations,
+            )
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+
+    override suspend fun getEpisodesBySeason(seasonId: String): List<Episode> {
+        return try {
+            val showId = seasonId.substringBefore("@")
+            val seasonNumber = seasonId.substringAfter("@")
+            val document = service.getPage(showId)
+            val seasonElement = document.select("div.se-c[data-season=$seasonNumber]")
+                .firstOrNull() ?: return emptyList()
+            seasonElement.select("ul.episodios li").map { episodeElement ->
+                val numerando = episodeElement.selectFirst("div.numerando")?.text() ?: "0 - 0"
+                val episodeNum = numerando.split("-").getOrNull(1)?.trim()?.toIntOrNull() ?: 0
+                val episodeTitle = episodeElement.selectFirst("div.epst > h3.title")?.text() ?: "Episodio $episodeNum"
+                Episode(
+                    id = episodeElement.selectFirst("a")!!.attr("href"),
+                    number = episodeNum,
+                    title = episodeTitle,
+                    poster = episodeElement.selectFirst("div.imagen > img")?.attr("src")
+                )
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun getServers(id: String, videoType: Video.Type): List<Video.Server> {
+        return try {
+            val doc = service.getPage(id)
+            val servers = mutableListOf<Video.Server>()
+            val linkElements = doc.select("li[data-type][data-post][data-nume]")
+
+            for (element in linkElements) {
+                val post = element.attr("data-post")
+                val nume = element.attr("data-nume")
+                val type = element.attr("data-type")
+
+                val formBody = FormBody.Builder()
+                    .add("action", "doo_player_ajax")
+                    .add("post", post)
+                    .add("nume", nume)
+                    .add("type", type)
+                    .build()
+
+                val ajaxResponse = service.getPlayerAjax(id, formBody)
+                val ajaxBody = ajaxResponse.body()?.string() ?: continue
+
+                val iframeUrl = ajaxBody.substringAfter("src='").substringBefore("'")
+                if (iframeUrl.isBlank()) continue
+
+                val iframeDoc = service.getPage(iframeUrl)
+                val iframeHtml = iframeDoc.html()
+
+                val dataLinkMatch = Regex("""dataLink = (\[.+?\]);""").find(iframeHtml)
+                if (dataLinkMatch != null) {
+                    val items = json.decodeFromString<List<Item>>(dataLinkMatch.groupValues[1])
+                    for (item in items) {
+                        val lang = when(item.video_language) {
+                            "LAT" -> "[LAT]"
+                            "ESP" -> "[CAST]"
+                            "SUB" -> "[SUB]"
+                            else -> ""
+                        }
+                        for (embed in item.sortedEmbeds) {
+                            val decryptedLink = decryptAES(embed.link) ?: continue
+                            servers.add(Video.Server(id = decryptedLink, name = "${embed.servername} $lang".trim()))
+                        }
+                    }
+                }
+            }
+            servers.distinctBy { it.id }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun decryptAES(encrypted: String): String? {
+        return try {
+            val key = "Ak7qrvvH4WKYxV2OgaeHAEg2a5eh16vE".toByteArray()
+            val decoded = Base64.decode(encrypted, Base64.DEFAULT)
+            val iv = decoded.copyOfRange(0, 16)
+            val cipherText = decoded.copyOfRange(16, decoded.size)
+            val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+            cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+            String(cipher.doFinal(cipherText))
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    override suspend fun getVideo(server: Video.Server): Video {
+        return Extractor.extract(server.id, server)
+    }
+
+    // Funciones no utilizadas por este proveedor
+    override suspend fun getPeople(id: String, page: Int): People {
+        throw Exception("Not used")
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/utils/CryptoAES.kt
+++ b/app/src/main/java/com/tanasi/streamflix/utils/CryptoAES.kt
@@ -1,0 +1,31 @@
+package com.tanasi.streamflix.utils
+
+import android.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+object CryptoAES {
+    fun decrypt(encryptedData: String, key: String): String {
+        return try {
+            val decodedData = Base64.decode(encryptedData, Base64.DEFAULT)
+
+            // Extraemos el IV de los primeros 16 bytes de los datos decodificados
+            val iv = decodedData.copyOfRange(0, 16)
+
+            // El resto son los datos cifrados
+            val ciphertext = decodedData.copyOfRange(16, decodedData.size)
+
+            val secretKeySpec = SecretKeySpec(key.toByteArray(), "AES")
+            val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, IvParameterSpec(iv))
+
+            val decryptedData = cipher.doFinal(ciphertext)
+
+            String(decryptedData)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            ""
+        }
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/utils/PlaylistUtils.kt
+++ b/app/src/main/java/com/tanasi/streamflix/utils/PlaylistUtils.kt
@@ -1,0 +1,93 @@
+package com.tanasi.streamflix.utils
+
+import androidx.media3.common.MimeTypes
+import com.tanasi.streamflix.models.Video
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+class PlaylistUtils(private val client: OkHttpClient) {
+
+    fun extractFromHls(
+        playlistUrl: String,
+        referer: String? = null,
+    ): List<Video> {
+        val masterPlaylist = try {
+            val request = Request.Builder().url(playlistUrl)
+            if (referer != null) {
+                request.header("Referer", referer)
+            }
+            client.newCall(request.build()).execute().body?.string() ?: ""
+        } catch (e: Exception) {
+            // Si la URL principal ya es un video, devuélvelo directamente
+            return listOf(Video(source = playlistUrl, subtitles = emptyList(), type = MimeTypes.APPLICATION_M3U8))
+        }
+
+        val videoList = mutableListOf<Video>()
+
+        if (!masterPlaylist.contains("#EXT-X-STREAM-INF")) {
+            videoList.add(
+                Video(
+                    source = playlistUrl,
+                    subtitles = emptyList(),
+                    type = MimeTypes.APPLICATION_M3U8
+                )
+            )
+            return videoList
+        }
+
+        val masterUrl = playlistUrl.toHttpUrl()
+        val masterBaseUrl = masterUrl.toString().substringBeforeLast("/") + "/"
+
+        // Obtener subtítulos de la playlist
+        val subtitles = SUBTITLE_REGEX.findAll(masterPlaylist).map {
+            val url = getAbsoluteUrl(it.groupValues[2], masterUrl.toString(), masterBaseUrl)
+            Video.Subtitle(
+                label = it.groupValues[1],
+                file = url,
+            )
+        }.toList()
+
+        masterPlaylist.substringAfter("#EXT-X-STREAM-INF:").split("#EXT-X-STREAM-INF:").forEach {
+            val resolution = RESOLUTION_REGEX.find(it)?.groupValues?.get(1)
+            val quality = resolution?.let { res -> "${res}p" } ?: getQualityFromBandwidth(it)
+            val url = getAbsoluteUrl(it.substringAfter("\n").trim(), masterUrl.toString(), masterBaseUrl)
+            val videoHeaders = referer?.let { mapOf("Referer" to it) }
+
+            videoList.add(
+                Video(
+                    source = url,
+                    subtitles = subtitles,
+                    type = MimeTypes.APPLICATION_M3U8,
+                    headers = videoHeaders
+                )
+            )
+        }
+        return videoList.sortedByDescending { it.source.contains("1080") }
+    }
+
+    private fun getAbsoluteUrl(url: String, playlistUrl: String, masterBase: String): String {
+        return when {
+            url.startsWith("http") -> url
+            url.startsWith("//") -> "https:$url"
+            url.startsWith("/") -> playlistUrl.toHttpUrl().scheme + "://" + playlistUrl.toHttpUrl().host + url
+            else -> masterBase + url
+        }
+    }
+
+    private fun getQualityFromBandwidth(text: String): String {
+        val bandwidth = BANDWIDTH_REGEX.find(text)?.groupValues?.get(1)?.toIntOrNull() ?: return "Default"
+        return when {
+            bandwidth >= 2000000 -> "1080p"
+            bandwidth >= 1000000 -> "720p"
+            bandwidth >= 600000 -> "480p"
+            else -> "360p"
+        }
+    }
+
+    companion object {
+        private val SUBTITLE_REGEX by lazy { Regex("""#EXT-X-MEDIA:TYPE=SUBTITLES.*?NAME="(.*?)".*?URI="(.*?)"""") }
+        private val RESOLUTION_REGEX by lazy { Regex("""RESOLUTION=\d{3,4}x(\d{3,4})""") }
+        private val BANDWIDTH_REGEX by lazy { Regex("""BANDWIDTH=(\d+)""") }
+    }
+}

--- a/app/src/main/java/com/tanasi/streamflix/utils/WebViewResolver.kt
+++ b/app/src/main/java/com/tanasi/streamflix/utils/WebViewResolver.kt
@@ -1,0 +1,47 @@
+package com.tanasi.streamflix.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class WebViewResolver(private val context: Context) {
+
+    private var webView: WebView? = null
+
+    suspend fun get(url: String, headers: Map<String, String> = emptyMap()): String = suspendCoroutine { continuation ->
+        val handler = Handler(Looper.getMainLooper())
+        handler.post {
+            webView = WebView(context).apply {
+                @SuppressLint("SetJavaScriptEnabled")
+                settings.javaScriptEnabled = true
+                webViewClient = object : WebViewClient() {
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        super.onPageFinished(view, url)
+                        view?.evaluateJavascript(
+                            "(function() { return ('<html>'+document.getElementsByTagName('html')[0].innerHTML+'</html>'); })();"
+                        ) { html ->
+                            continuation.resume(html.trim().removeSurrounding("\""))
+                            release()
+                        }
+                    }
+                }
+                loadUrl(url, headers)
+            }
+        }
+    }
+
+    private fun release() {
+        val handler = Handler(Looper.getMainLooper())
+        handler.post {
+            webView?.stopLoading()
+            webView?.destroy()
+            webView = null
+        }
+    }
+}


### PR DESCRIPTION
feat(extractor): add OkruExtractor

This commit introduces a new extractor for Ok.ru video links.

**OkruExtractor.kt (New):**
- Implemented `OkruExtractor` to parse video links from Ok.ru.
- The extractor fetches the Ok.ru page and extracts video information from the `data-options` attribute of a specific div.
- It parses a JSON-like string to find video URLs and their corresponding qualities.
- A `fixQuality` function is used to map Ok.ru's quality labels (e.g., "ultra", "full") to standard resolutions (e.g., "2160p", "1080p").
- The extractor selects the best available quality by default.
- It includes a Retrofit service with a custom OkHttpClient that sets a User-Agent header and follows redirects.

**Extractor.kt (Update):**
- Added `OkruExtractor` to the list of available extractors.