### PR TITLE
fix VixcloudExtractor e streamingcommunity

### DIFF
--- a/app/src/main/java/com/tanasi/streamflix/extractors/VixcloudExtractor.kt
+++ b/app/src/main/java/com/tanasi/streamflix/extractors/VixcloudExtractor.kt
@@ -1,5 +1,6 @@
 package com.tanasi.streamflix.extractors
 
+import android.util.Log
 import androidx.media3.common.MimeTypes
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
@@ -17,85 +18,123 @@ class VixcloudExtractor : Extractor() {
     override val name = "vixcloud"
     override val mainUrl = "https://vixcloud.co/"
 
+    private fun sanitizeJsonKeysAndQuotes(jsonLikeString: String): String {
+        var temp = jsonLikeString
+        // Replace Javascript style single quotes with JSON double quotes
+        temp = temp.replace("'", "\"")
+        // Quote known keys if they appear as key: (e.g. id:, filename:, token:, expires:, asn:)
+        // Use a raw string for the regex pattern and a lambda for replacement.
+        temp = Regex("""(\b(?:id|filename|token|expires|asn)\b)\s*:""").replace(temp) { matchResult ->
+            '"' + matchResult.groupValues[1] + "\":"
+        }
+        return temp
+    }
+
+    private fun removeTrailingCommaFromJsonObjectString(jsonString: String): String {
+        var temp = jsonString.trim()
+        val lastBraceIndex = temp.lastIndexOf('}')
+        if (lastBraceIndex > 0 && temp.startsWith("{")) {
+            var charIndexBeforeBrace = lastBraceIndex - 1
+            while (charIndexBeforeBrace >= 0 && temp[charIndexBeforeBrace].isWhitespace()) {
+                charIndexBeforeBrace--
+            }
+            if (charIndexBeforeBrace >= 0 && temp[charIndexBeforeBrace] == ',') {
+                // Reconstruct string without the trailing comma
+                return temp.substring(0, charIndexBeforeBrace) + temp.substring(charIndexBeforeBrace + 1)
+            }
+        }
+        return jsonString // Return original if no modification was made or not applicable
+    }
+
     override suspend fun extract(link: String): Video {
         val service = VixcloudExtractorService.build(mainUrl)
         val source = service.getSource(link.replace(mainUrl, ""))
 
-        // parsing json info
         val scriptText = source.body().selectFirst("script")?.data() ?: ""
+        Log.d("VixcloudDebug", "scriptText content: <<<" + scriptText + ">>>")
 
-        val videoJson = scriptText
-            .substringAfter("window.video = ")
-            .substringBefore(";")
-        val masterPlaylistJson = scriptText
-            .substringAfter("window.masterPlaylist")
-            .substringAfter("params: ")
-            .replace("'token'", "token")
-            .replace("'expires'", "expires")
-            .replace("'", "\"")
-            .substringBefore("}")
-            .substringBeforeLast(",") + "}"
+        var videoJson = scriptText
+            .substringAfter("window.video = ", "")
+            .substringBefore(";", "")
+            .trim()
+        Log.d("VixcloudDebug", "Original videoJson: <<<" + videoJson + ">>>")
+        if (videoJson.isNotEmpty()) {
+            videoJson = sanitizeJsonKeysAndQuotes(videoJson)
+            videoJson = removeTrailingCommaFromJsonObjectString(videoJson)
+            // Ensure it's actually an object, in case of unexpected extraction
+            if (!videoJson.startsWith("{") && videoJson.contains(":")) videoJson = "{$videoJson"
+            if (!videoJson.endsWith("}") && videoJson.contains(":")) videoJson = "$videoJson}"
+        }
+        Log.d("VixcloudDebug", "Processed videoJson: <<<" + videoJson + ">>>")
+
+        val paramsObjectContent = scriptText
+            .substringAfter("window.masterPlaylist", "")
+            .substringAfter("params: {", "")
+            .substringBefore("},", "") // This gets content between 'params: {' and '},'
+            .trim()
+        Log.d("VixcloudDebug", "Extracted paramsObjectContent: <<<" + paramsObjectContent + ">>>")
+
+        var masterPlaylistJson: String
+        if (paramsObjectContent.isNotEmpty()) {
+            var processedParams = sanitizeJsonKeysAndQuotes(paramsObjectContent)
+            // Remove trailing comma from the *content* string before wrapping with braces
+            processedParams = processedParams.trim()
+            if (processedParams.endsWith(",")) {
+                processedParams = processedParams.substring(0, processedParams.length - 1).trim()
+            }
+            masterPlaylistJson = "{${processedParams}}"
+        } else {
+            masterPlaylistJson = "{}"
+        }
+        Log.d("VixcloudDebug", "Processed masterPlaylistJson: <<<" + masterPlaylistJson + ">>>")
 
         val hasBParam = scriptText
-            .substringAfter("url:")
-            .substringBefore(",")
+            .substringAfter("url:", "")
+            .substringBefore(",", "")
             .contains("b=1")
 
         val gson = Gson()
         val windowVideo = gson.fromJson(videoJson, VixcloudExtractorService.WindowVideo::class.java)
         val masterPlaylist = gson.fromJson(masterPlaylistJson, VixcloudExtractorService.WindowParams::class.java)
 
-        //
-        val masterParams = mutableMapOf(
-            "token" to masterPlaylist.token,
-            "expires" to masterPlaylist.expires
-        )
+        val masterParams = mutableMapOf<String, String>()
+        if (masterPlaylist?.token != null) {
+            masterParams["token"] = masterPlaylist.token
+        }
+        if (masterPlaylist?.expires != null) {
+            masterParams["expires"] = masterPlaylist.expires
+        }
 
-        // parse parameters from source url
-        val currentParams = link
-            .split("&")
+        val currentParams = link.split("&")
             .map { param -> param.split("=") }
             .filter { it.size == 2 }
             .associate { it[0] to it[1] }
 
-        if (hasBParam)
-            masterParams["b"] = "1"
+        if (hasBParam) masterParams["b"] = "1"
+        if (currentParams.containsKey("canPlayFHD")) masterParams["h"] = "1"
 
-        if (currentParams.containsKey("canPlayFHD"))
-            masterParams["h"] = "1"
-
-        // final playlist url
         val baseUrl = "https://vixcloud.co/playlist/${windowVideo.id}"
-
         val httpUrlBuilder = baseUrl.toHttpUrlOrNull()?.newBuilder()
             ?: throw IllegalArgumentException("Invalid base URL")
-
-        for ((key, value) in masterParams)
-            httpUrlBuilder.addQueryParameter(key, value)
-
+        masterParams.forEach { (key, value) -> httpUrlBuilder.addQueryParameter(key, value) }
         val finalUrl = httpUrlBuilder.build().toString()
 
         return Video(
             source = finalUrl,
             subtitles = listOf(),
             type = MimeTypes.APPLICATION_M3U8,
-            headers = mapOf(
-                "Referer" to mainUrl,
-                "User-Agent" to "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-            )
+            headers = mapOf("Referer" to mainUrl, "User-Agent" to "Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
         )
     }
 
     private interface VixcloudExtractorService {
-
         companion object {
             fun build(baseUrl: String): VixcloudExtractorService {
-                val retrofit = Retrofit.Builder()
+                return Retrofit.Builder()
                     .baseUrl(baseUrl)
                     .addConverterFactory(JsoupConverterFactory.create())
                     .build()
-
-                return retrofit.create(VixcloudExtractorService::class.java)
+                    .create(VixcloudExtractorService::class.java)
             }
         }
 
@@ -109,8 +148,8 @@ class VixcloudExtractor : Extractor() {
         )
 
         data class WindowParams(
-            @SerializedName("token") val token: String,
-            @SerializedName("expires") val expires: String
+            @SerializedName("token") val token: String?,
+            @SerializedName("expires") val expires: String?
         )
     }
 }

--- a/app/src/main/java/com/tanasi/streamflix/extractors/VixcloudExtractor.kt
+++ b/app/src/main/java/com/tanasi/streamflix/extractors/VixcloudExtractor.kt
@@ -31,7 +31,7 @@ class VixcloudExtractor : Extractor() {
     }
 
     private fun removeTrailingCommaFromJsonObjectString(jsonString: String): String {
-        var temp = jsonString.trim()
+        val temp = jsonString.trim() // Changed var to val
         val lastBraceIndex = temp.lastIndexOf('}')
         if (lastBraceIndex > 0 && temp.startsWith("{")) {
             var charIndexBeforeBrace = lastBraceIndex - 1


### PR DESCRIPTION
fix(VixcloudExtractor): Improve JSON parsing, data extraction, and code style

This commit addresses and resolves JSON parsing errors in the VixcloudExtractor
by implementing more robust sanitization and extraction logic, and also
addresses an IDE warning for better code style.

Key changes include:

- JSON Sanitization:
    - Replaced single quotes with double quotes for string values.
    - Correctly quoted unquoted object keys (e.g., `id:`, `filename:`, `token:`)
      using a regular expression with a raw string pattern and a lambda
      replacement function to overcome Kotlin escape sequence issues.
    - Implemented a more robust method to remove trailing commas from
      JSON object strings.

- Extraction Logic:
    - Refined substring operations to more accurately isolate `videoJson`
      and the `params` object for `masterPlaylistJson` from the source script.

- Robustness:
    - Made `token` and `expires` fields in the `WindowParams` data class
      nullable to handle cases where these might be missing after parsing.

- Code Style:
    - Changed `var` to `val` for a variable in `removeTrailingCommaFromJsonObjectString`
      that was never reassigned, as per IDE recommendations.

- Debugging:
    - Added detailed Logcat statements (tag: VixcloudDebug) to trace the
      JSON transformation process, which were instrumental in diagnosing
      and fixing the parsing issues.